### PR TITLE
Deal with ValueError exceptions from the email.utils timestamp code.

### DIFF
--- a/maildir-deduplicate.py
+++ b/maildir-deduplicate.py
@@ -251,7 +251,7 @@ def get_canonical_header_value(header, value):
         try:
             parsed = email.utils.parsedate_tz(value)
             utc_timestamp = email.utils.mktime_tz(parsed)
-        except TypeError: # if parsedate_tz cannot parse the date
+        except (TypeError, ValueError): # if parsedate_tz cannot parse the date
             return value
 
         return time.strftime('%Y/%m/%d UTC', time.gmtime(utc_timestamp))


### PR DESCRIPTION
Got an error like this:
  File "./maildir-deduplicate.py", line 253, in get_canonical_header_value
    utc_timestamp = email.utils.mktime_tz(parsed)
  File "/usr/lib/python2.6/email/_parseaddr.py", line 146, in mktime_tz
    t = time.mktime(data[:8] + (0,))
ValueError: year out of range

This should avoid it.
