### PR TITLE
fix hash-pipe by adding missing (unused) first argument to compute_hash_key

### DIFF
--- a/maildir-deduplicate.py
+++ b/maildir-deduplicate.py
@@ -555,7 +555,7 @@ def debug_hash_algorithm(opts):
     #mail_text = ''.join(sys.stdin.readlines())
     #message = email.message_from_string(mail_text)
     message = email.message_from_file(sys.stdin)
-    mail_hash, header_text = compute_hash_key(message, opts.message_id)
+    mail_hash, header_text = compute_hash_key(None, message, opts.message_id)
     print header_text
     print 'Hash:', mail_hash
 


### PR DESCRIPTION
The -H option was not working for me. I have added an unused argument to replace the missing argument for compute_hash_key
