### PR TITLE
add newline when returning pretty_canonical_headers (fixes #155)

### DIFF
--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -86,12 +86,12 @@ STATS_DEF = OrderedDict(
         (
             "set_skipped_size",
             "Number of sets skipped from the selection process because they were "
-            "too disimilar in size.",
+            "too dissimilar in size.",
         ),
         (
-            "set_skipeed_content",
+            "set_skipped_content",
             "Number of sets skipped from the selection process because they were "
-            "too disimilar in content.",
+            "too dissimilar in content.",
         ),
         (
             "set_skipped_strategy",

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -38,8 +38,8 @@ STATS_DEF = OrderedDict(
         ("mail_found", "Total number of mails encountered from all mail sources."),
         (
             "mail_rejected",
-            "Number of mails individuality rejected because they were unparseable or "
-            "did not had enough metadata to compute hashes.",
+            "Number of mails rejected individually because they were unparseable or "
+            "did not have enough metadata to compute hashes.",
         ),
         (
             "mail_retained",

--- a/mail_deduplicate/mail.py
+++ b/mail_deduplicate/mail.py
@@ -231,7 +231,7 @@ class DedupMail:
         Returns a string ready to be printing to user or for debugging.
         """
         table = [["Header ID", "Header value"]] + list(self.canonical_headers)
-        return tabulate(table, tablefmt="fancy_grid", headers="firstrow")
+        return "\n" + tabulate(table, tablefmt="fancy_grid", headers="firstrow")
 
     @cachedproperty
     def serialized_headers(self):


### PR DESCRIPTION
We should first log a newline to "break out" of the progress bar as shown in #155