### PR TITLE
add newline when returning pretty_canonical_headers (fixes #155)

### DIFF
--- a/mail_deduplicate/mail.py
+++ b/mail_deduplicate/mail.py
@@ -231,7 +231,7 @@ class DedupMail:
         Returns a string ready to be printing to user or for debugging.
         """
         table = [["Header ID", "Header value"]] + list(self.canonical_headers)
-        return tabulate(table, tablefmt="fancy_grid", headers="firstrow")
+        return "\n" + tabulate(table, tablefmt="fancy_grid", headers="firstrow")
 
     @cachedproperty
     def serialized_headers(self):

--- a/mail_deduplicate/mailbox.py
+++ b/mail_deduplicate/mailbox.py
@@ -134,7 +134,7 @@ def open_box(path, box_type=False, force_unlock=False):
     If ``box_type`` is provided, forces the opening of the box in the specified format.
     Defaults to (crude) autodetection.
     """
-    logger.info(f"Opening {choice_style(path)} ...")
+    logger.info(f"\nOpening {choice_style(path)} ...")
     path = Path(path)
     if not box_type:
         box_type = autodetect_box_type(path)


### PR DESCRIPTION
We should first log a newline to "break out" of the progress bar as shown in #155.  

I've since found at least one other occasion of a similar logging issue and will push further commits to this branch and PR as I become aware of them.

#### Preliminary checks

* [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/develop/.github/code-of-conduct.md)
* [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
* [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address