### PR TITLE
Add option to only act on duplicate messages

### DIFF
--- a/mail_deduplicate/__init__.py
+++ b/mail_deduplicate/__init__.py
@@ -118,6 +118,7 @@ class Config:
     default_conf = {
         "dry_run": False,
         "input_format": False,
+        "only_act_on_duplicates": False,
         "force_unlock": False,
         "hash_only": False,
         "hash_headers": HASH_HEADERS,

--- a/mail_deduplicate/cli.py
+++ b/mail_deduplicate/cli.py
@@ -94,6 +94,13 @@ def validate_regexp(ctx, param, value):
     "format, or bypass unreliable detection.",
 )
 @click.option(
+    "-o",
+    "--only-act-on-duplicates",
+    is_flag=True,
+    default=False,
+    help="Perform any actions only on duplicate messages, not on unique messages.",
+)
+@click.option(
     "-u",
     "--force-unlock",
     is_flag=True,
@@ -239,6 +246,7 @@ def mdedup(
     ctx,
     dry_run,
     input_format,
+    only_act_on_duplicates,
     force_unlock,
     hash_only,
     hash_header,
@@ -346,6 +354,7 @@ def mdedup(
     conf = Config(
         dry_run=dry_run,
         input_format=input_format,
+        only_act_on_duplicates=only_act_on_duplicates,
         force_unlock=force_unlock,
         hash_only=hash_only,
         hash_headers=hash_header,

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -48,7 +48,8 @@ STATS_DEF = OrderedDict(
         ("mail_hashes", "Number of unique hashes."),
         (
             "mail_unique",
-            "Number of unique mails (which where automatically added to selection).",
+            "Number of unique mails (which where automatically added to selection "
+            "unless --only-act-on-duplicates was passed on the command line).",
         ),
         (
             "mail_duplicates",
@@ -404,9 +405,10 @@ class Deduplicate:
             if mail_count == 1:
                 logger.debug("Add unique message to selection.")
                 self.stats["mail_unique"] += 1
-                self.stats["mail_selected"] += 1
-                self.stats["set_single"] += 1
-                candidates = mail_set
+                if self.conf.only_act_on_duplicates is False:
+                    self.stats["mail_selected"] += 1
+                    self.stats["set_single"] += 1
+                    candidates = mail_set
 
             # We need to resort to a selection strategy to discriminate mails
             # within the set.
@@ -457,9 +459,12 @@ class Deduplicate:
         # Mail grouping by hash.
         assert self.stats["mail_retained"] >= self.stats["mail_unique"]
         assert self.stats["mail_retained"] >= self.stats["mail_duplicates"]
-        assert self.stats["mail_retained"] == (
-            self.stats["mail_unique"] + self.stats["mail_duplicates"]
-        )
+        if self.conf.only_act_on_duplicates:
+            assert self.stats["mail_retained"] == self.stats["mail_duplicates"]
+        else:
+            assert self.stats["mail_retained"] == (
+                self.stats["mail_unique"] + self.stats["mail_duplicates"]
+            )
         # Mail selection stats.
         assert self.stats["mail_retained"] >= self.stats["mail_skipped"]
         assert self.stats["mail_retained"] >= self.stats["mail_discarded"]


### PR DESCRIPTION
#### Summary

This PR fixes/implements the following bugs/features:

* Adds an option to ignore single messages during execution, but only when selected. The default behavior is the same as before this change.

This PR fixes #203.

#### Preliminary checks

* [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/develop/.github/code-of-conduct.md)
* [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
* [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

#### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

I'm not sure what the tests should look like, and will take any suggestions for those.