### PR TITLE
fix dynamic mailbox inheritance (fixes #191)

### DIFF
--- a/mail_deduplicate/mail.py
+++ b/mail_deduplicate/mail.py
@@ -49,9 +49,10 @@ class DedupMail:
         # Hunt down in our parent classes (but ourselve) the first one inheriting the
         # mailbox.Message class. That way we can get to the original factory.
         orig_message_klass = None
-        for klass in inspect.getmro(self.__class__)[1:]:
+        mro = inspect.getmro(self.__class__)
+        for i, klass in enumerate(mro[1:], 1):
             if issubclass(klass, mailbox.Message):
-                orig_message_klass = klass
+                orig_message_klass = mro[i-1]
                 break
         assert orig_message_klass
 


### PR DESCRIPTION
The `DedupMail` mixin class went to great lengths to find the proper
superclass to call a constructor on. However, this ended up calling the
ctor of `Message` for `MaildirMessage` because `super(k, o)` doesn't call the
`k` constructor in the MRO of `o`, but starts with the next one.

This just fixes the MRO search so that `MaildirMessage` is the `ctor` to
call, assuming the dynamic base-class lookup was a good idea to begin
with :)