### PR TITLE
🐛 skip set if no mail selected

### DIFF
--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -284,6 +284,16 @@ class DuplicateSet:
             self.stats["set_skipped_strategy"] += 1
             return
 
+        # Duplicate sets matching none are skipped altogether.
+        if candidate_count == 0:
+            logger.warning(
+                f"Skip set: No mail within were selected. "
+                "The strategy criterion was not able to select some."
+            )
+            self.stats["mail_skipped"] += self.size
+            self.stats["set_skipped_strategy"] += 1
+            return
+
         logger.info(f"{candidate_count} mail candidates selected for action.")
         self.stats["mail_selected"] += candidate_count
         self.stats["mail_discarded"] += self.size - candidate_count


### PR DESCRIPTION
#### Summary

If no mail are selected by the strategy (with regexp for example), it could lead to message loss because it means all will be discarded.
I think that the desired behavior is to skip the set like when all mail are selected.

#### Preliminary checks

* [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/develop/.github/code-of-conduct.md)
* [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
* [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

#### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
