### PR TITLE
Feat/body hasher

### DIFF
--- a/mail_deduplicate/__init__.py
+++ b/mail_deduplicate/__init__.py
@@ -121,6 +121,7 @@ class Config:
         "force_unlock": False,
         "hash_only": False,
         "hash_headers": HASH_HEADERS,
+        "hash_body": None,
         "size_threshold": DEFAULT_SIZE_THRESHOLD,
         "content_threshold": DEFAULT_CONTENT_THRESHOLD,
         "show_diff": False,

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -116,8 +116,8 @@ BODY_HASHER_NORMALIZED = "normalized"
 BODY_HASHERS = FrozenDict(
     {
         BODY_HASHER_SKIP: lambda _: "",
-        BODY_HASHER_RAW: None,
-        BODY_HASHER_NORMALIZED: None,
+        BODY_HASHER_RAW: lambda m: m.hash_raw_body,
+        BODY_HASHER_NORMALIZED: lambda m: m.hash_normalized_body,
     }
 )
 

--- a/mail_deduplicate/mail.py
+++ b/mail_deduplicate/mail.py
@@ -200,6 +200,24 @@ class DedupMail:
         return hash_value
 
     @cachedproperty
+    def hash_raw_body(self):
+        """ Returns the canonical body hash of a mail. """
+        serialized_raw_body = "\n".join(self.body_lines).encode("utf-8")
+        hash_value = hashlib.sha224(serialized_raw_body).hexdigest()
+        logger.debug(f"Body raw hash: {hash_value}")
+        return hash_value
+
+    @cachedproperty
+    def hash_normalized_body(self):
+        """ Returns the normalized body hash of a mail. """
+        serialized_normalized_body = "".join(
+            [re.sub(r"\s", "", l) for l in self.body_lines]
+        ).encode("utf-8")
+        hash_value = hashlib.sha224(serialized_normalized_body).hexdigest()
+        logger.debug(f"Body normalized hash: {hash_value}")
+        return hash_value
+
+    @cachedproperty
     def canonical_headers(self):
         """Returns the full list of all canonical headers names and values in
         preparation for hashing."""


### PR DESCRIPTION
#### Summary

Add an option to include body hash for duplicate detection.
Implements body hasher with three options:
* Skip: do not include body hash for duplicate detection (same behavior as now)
* Raw: use the body lines as they are.
* Normalized: use the joined body lines removing spaces and carriage returns

#### Preliminary checks

* [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/develop/.github/code-of-conduct.md)
* [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
* [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

#### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
