### PR TITLE
Reduce memory usage of mail object

### DIFF
--- a/mail_deduplicate/cli.py
+++ b/mail_deduplicate/cli.py
@@ -399,7 +399,7 @@ def mdedup(
         for all_mails in dedup.mails.values():
             for mail in all_mails:
                 echo(mail.pretty_headers)
-                echo(f"Hash: {mail.hash_key}")
+                echo(f"Hash: {mail.hash_key()}")
         ctx.exit()
 
     echo(theme.heading("\n● Step #3 - Select mails in each group"))

--- a/mail_deduplicate/mail.py
+++ b/mail_deduplicate/mail.py
@@ -189,11 +189,11 @@ class DedupMail:
         subject, _ = re.subn(r"\s+", " ", subject)
         return subject
 
-    @cached_property
+    # Do not cache to reduce memory
     def hash_key(self):
         """Returns the canonical hash of a mail."""
-        logger.debug(f"Serialized headers: {self.serialized_headers!r}")
-        hash_value = hashlib.sha224(self.serialized_headers).hexdigest()
+        logger.debug(f"Serialized headers: {self.serialized_headers()!r}")
+        hash_value = hashlib.sha224(self.serialized_headers()).hexdigest()
         logger.debug(f"Hash: {hash_value}")
         return hash_value
 
@@ -239,7 +239,7 @@ class DedupMail:
         # Cast to a tuple to prevent any modification.
         return tuple(canonical_headers)
 
-    @cached_property
+    # Do not cache to reduce memory
     def pretty_canonical_headers(self):
         """Renders a table of headers names and values used to produce the mail's hash.
 
@@ -248,7 +248,7 @@ class DedupMail:
         table = [["Header ID", "Header value"], *list(self.canonical_headers)]
         return "\n" + tabulate(table, tablefmt="fancy_grid", headers="firstrow")
 
-    @cached_property
+    # Do not cache to reduce memory
     def serialized_headers(self):
         """Serialize the canonical headers into a single string ready to be hashed.
 
@@ -256,13 +256,13 @@ class DedupMail:
         """
         headers_count = len(self.canonical_headers)
         if headers_count < MINIMAL_HEADERS_COUNT:
-            logger.warning(self.pretty_canonical_headers)
+            logger.warning(self.pretty_canonical_headers())
             msg = f"{headers_count} headers found out of {MINIMAL_HEADERS_COUNT}."
             raise TooFewHeaders(
                 msg,
             )
         else:
-            logger.debug(self.pretty_canonical_headers)
+            logger.debug(self.pretty_canonical_headers())
 
         return "\n".join(
             [f"{h_id}: {h_value}" for h_id, h_value in self.canonical_headers],


### PR DESCRIPTION
Mail object has data in `__dict__` that can be removed in some cases.

- not cache attributes that are not critical for performance
- some attributes can be removed after build_sets. `_payload` and `body_lines` may be large

#### Summary

<!-- You can skip this if you're proposing something as trivial as fixing a typo -->

This PR fixes/implements the following bugs/features:

- [x] Bug #362

Explain the motivation for making this change. What existing problem does the pull request solve?

#### Preliminary checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/main/.github/code-of-conduct.md)
- [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
- [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [x] Does your submission pass tests?
1. [x] Have you lint your code locally prior to submission?

#### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
