### PR TITLE
Fix assert on move-discarded

### DIFF
--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -503,7 +503,8 @@ class Deduplicate:
         )
         # Action stats.
         assert self.stats["mail_selected"] >= self.stats["mail_copied"]
-        assert self.stats["mail_selected"] >= self.stats["mail_moved"]
+        if self.conf.action != "move-discarded":
+            assert self.stats["mail_selected"] >= self.stats["mail_moved"]
         assert self.stats["mail_selected"] >= self.stats["mail_deleted"]
         assert self.stats["mail_selected"] in (
             self.stats["mail_copied"],


### PR DESCRIPTION
mail_moved may be larger than mail_selected on move-discarded.

#### Summary

Mail moved size may be larger than mail selected size on move-discarded since discard mails are moved.

Explain the motivation for making this change. What existing problem does the pull request solve?

#### Preliminary checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/main/.github/code-of-conduct.md)
- [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
- [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [x] Does your submission pass tests?
1. [x] Have you lint your code locally prior to submission?

#### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
