### PR TITLE
fix: don't retain original line endings

### DIFF
--- a/mail_deduplicate/mail.py
+++ b/mail_deduplicate/mail.py
@@ -142,7 +142,7 @@ class DedupMail:
         """Return a normalized list of lines from message's body."""
         body = []
         if self.preamble is not None:
-            body.extend(self.preamble.splitlines(keepends=True))
+            body.extend(self.preamble.splitlines())
 
         for part in self.walk():
             if part.is_multipart():
@@ -173,10 +173,10 @@ class DedupMail:
                 else:
                     part_body = part.get_payload(decode=False)
 
-            body.extend(part_body.splitlines(keepends=True))
+            body.extend(part_body.splitlines())
 
         if self.epilogue is not None:
-            body.extend(self.epilogue.splitlines(keepends=True))
+            body.extend(self.epilogue.splitlines())
         return body
 
     @cached_property


### PR DESCRIPTION
`body` is now a list of lines without line endings. Fixes #844.

#### Summary

This PR fixes #844.

Much of the rest of the codebase seems to assume `body` does not have newlines. However, I have not checked extensively and do not know why `keepends=True` was added in the first place.

#### Preliminary checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/main/.github/code-of-conduct.md)
- [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
- [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [x] Does your submission pass tests?
2. [ ] Have you lint your code locally prior to submission? - no

#### Changes to Core Features:

Fix to existing feature. Should be covered by tests.

Another test could be added to ensure emails with different line endings are determined to be identical.
