### PR TITLE
fix: `From: "Bob"` == `From: Bob`

### DIFF
--- a/mail_deduplicate/__init__.py
+++ b/mail_deduplicate/__init__.py
@@ -60,6 +60,39 @@ By default we choose to exclude:
 """
 
 
+ADDRESS_HEADERS = frozenset([
+    "from",
+    "to",
+    "cc",
+    "bcc",
+    "reply-to",
+    "sender",
+    "return-path",
+    "resent-from",
+    "resent-to",
+    "resent-cc",
+    "resent-bcc",
+    "resent-reply-to",
+    "resent-sender",
+    "delivered-to",
+    "x-original-to",
+    "envelope-to",
+    "x-envelope-from",
+    "x-envelope-to",
+    "disposition-notification-to",
+    "original-recipient"
+])
+"""Headers that contain email addresses."""
+
+
+QUOTE_DISCARD_HEADERS = ADDRESS_HEADERS
+"""Headers from which quotes should be discarded.
+
+E.g. "Bob" <bob@example.com> should hash to the same thing as
+       Bob <bob@example.com>
+"""
+
+
 MINIMAL_HEADERS_COUNT = 4
 """Below this value, we consider not having enough headers to compute a solid hash."""
 


### PR DESCRIPTION
#### Summary

Remove quotes in any headers that contain addresses to ensure a quoted name is hashed to the same value as an unquoted one. Fixes #846.

This may not be the cleanest way to normalize email addresses. E.g. `"Robert \"Bob\"` becomes `Robert \Bob\`, but this shouldn't matter for hashing purposes as we're just trying to get a good heuristic.

#### Preliminary checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/main/.github/code-of-conduct.md)
- [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
- [x] I have checked there is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

1. [x] Does your submission pass tests?
1. [ ] Have you lint your code locally prior to submission? - No

#### Changes to Core Features:

N/a. Fixes an existing feature.

A test could be added to ensure `"Bob"` hashes the same as `Bob`.
