### PR TITLE
Add checks for unique email

### DIFF
--- a/mail_deduplicate/action.py
+++ b/mail_deduplicate/action.py
@@ -158,6 +158,7 @@ class Action(Enum):
         # Check our indexing and selection methods are not flagging candidates
         # several times.
         assert len(unique(dedup.selection)) == len(dedup.selection)
-        assert len(dedup.selection) == dedup.stats["mail_selected"]
+        assert len(
+            dedup.selection) == dedup.stats["mail_selected"] + dedup.stats["mail_unique"]
 
         self.action_function(dedup)

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -406,8 +406,7 @@ class Deduplicate:
 
         # Open and register the mail source. Subfolders will be registered as their
         # own box.
-        boxes = open_box(
-            path, self.conf["input_format"], self.conf["force_unlock"])
+        boxes = open_box(path, self.conf["input_format"], self.conf["force_unlock"])
         for box in boxes:
             self.sources[box._path] = box
 
@@ -474,8 +473,7 @@ class Deduplicate:
             # Alter log level depending on set length.
             mail_count = len(mail_set)
             log_level = logging.debug if mail_count == 1 else logging.info
-            log_level(theme.subheading(
-                f"◼ {mail_count} mails sharing hash {hash_key}"))
+            log_level(theme.subheading(f"◼ {mail_count} mails sharing hash {hash_key}"))
 
             # Apply the selection strategy to discriminate mails within the set.
             duplicates = DuplicateSet(hash_key, mail_set, self.conf)
@@ -520,7 +518,7 @@ class Deduplicate:
                 if stat_id.startswith(prefix):
                     table.append(
                         [
-                            stat_id[len(prefix):].replace("_", " - ").title(),
+                            stat_id[len(prefix) :].replace("_", " - ").title(),
                             self.stats[stat_id],
                             "\n".join(textwrap.wrap(desc, 60)),
                         ],
@@ -584,8 +582,7 @@ class Deduplicate:
         self.stats["mail_unique + mail_duplicates"] = (
             self.stats["mail_unique"] + self.stats["mail_duplicates"]
         )
-        self.assert_stats("mail_retained", "==",
-                          "mail_unique + mail_duplicates")
+        self.assert_stats("mail_retained", "==", "mail_unique + mail_duplicates")
 
         # Mail selection stats.
         self.assert_stats("mail_retained", ">=", "mail_skipped")

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -406,7 +406,8 @@ class Deduplicate:
 
         # Open and register the mail source. Subfolders will be registered as their
         # own box.
-        boxes = open_box(path, self.conf["input_format"], self.conf["force_unlock"])
+        boxes = open_box(
+            path, self.conf["input_format"], self.conf["force_unlock"])
         for box in boxes:
             self.sources[box._path] = box
 
@@ -473,7 +474,8 @@ class Deduplicate:
             # Alter log level depending on set length.
             mail_count = len(mail_set)
             log_level = logging.debug if mail_count == 1 else logging.info
-            log_level(theme.subheading(f"◼ {mail_count} mails sharing hash {hash_key}"))
+            log_level(theme.subheading(
+                f"◼ {mail_count} mails sharing hash {hash_key}"))
 
             # Apply the selection strategy to discriminate mails within the set.
             duplicates = DuplicateSet(hash_key, mail_set, self.conf)
@@ -518,7 +520,7 @@ class Deduplicate:
                 if stat_id.startswith(prefix):
                     table.append(
                         [
-                            stat_id[len(prefix) :].replace("_", " - ").title(),
+                            stat_id[len(prefix):].replace("_", " - ").title(),
                             self.stats[stat_id],
                             "\n".join(textwrap.wrap(desc, 60)),
                         ],
@@ -582,31 +584,38 @@ class Deduplicate:
         self.stats["mail_unique + mail_duplicates"] = (
             self.stats["mail_unique"] + self.stats["mail_duplicates"]
         )
-        self.assert_stats("mail_retained", "==", "mail_unique + mail_duplicates")
+        self.assert_stats("mail_retained", "==",
+                          "mail_unique + mail_duplicates")
 
         # Mail selection stats.
         self.assert_stats("mail_retained", ">=", "mail_skipped")
         self.assert_stats("mail_retained", ">=", "mail_discarded")
         self.assert_stats("mail_retained", ">=", "mail_selected")
 
-        self.stats["mail_skipped + mail_discarded + mail_selected"] = (
-            self.stats["mail_skipped"]
+        self.stats["mail_unique + mail_skipped + mail_discarded + mail_selected"] = (
+            self.stats["mail_unique"]
+            + self.stats["mail_skipped"]
             + self.stats["mail_discarded"]
             + self.stats["mail_selected"]
         )
         self.assert_stats(
-            "mail_retained", "==", "mail_skipped + mail_discarded + mail_selected"
+            "mail_retained", "==", "mail_unique + mail_skipped + mail_discarded + mail_selected"
         )
 
         # Action stats.
-        self.assert_stats("mail_selected", ">=", "mail_copied")
+        self.stats["mail_unique + mail_selected"] = (
+            self.stats["mail_unique"]
+            + self.stats["mail_selected"]
+        )
+        self.assert_stats("mail_unique + mail_selected", ">=", "mail_copied")
         if self.conf["action"] != "move-discarded":
             # The number of moved mails may be larger than the number of selected
             # mails for move-discarded action, because discarded mails are moved.
             self.assert_stats("mail_selected", ">=", "mail_moved")
         self.assert_stats("mail_selected", ">=", "mail_deleted")
         self.assert_stats(
-            "mail_selected", "in", ["mail_copied", "mail_moved", "mail_deleted"]
+            "mail_unique + mail_selected", "in", [
+                "mail_copied", "mail_moved", "mail_deleted"]
         )
         # Sets accounting.
         self.assert_stats("set_total", "==", "mail_hashes")

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -299,6 +299,14 @@ class DuplicateSet:
         The process results in two subsets of mails: the selected and the discarded.
         """
         # Fine-grained checks on mail differences.
+
+        if self.size == 1:
+            self.stats["set_single"] += 1
+            self.stats["mail_unique"] += 1
+            self.stats["mail_duplicates"] = 0
+            self.selection = set(self.pool)
+            return
+
         try:
             self.check_differences()
         except UnicodeDecodeError as expt:

--- a/mail_deduplicate/deduplicate.py
+++ b/mail_deduplicate/deduplicate.py
@@ -612,7 +612,7 @@ class Deduplicate:
             # The number of moved mails may be larger than the number of selected
             # mails for move-discarded action, because discarded mails are moved.
             self.assert_stats("mail_selected", ">=", "mail_moved")
-        self.assert_stats("mail_selected", ">=", "mail_deleted")
+        self.assert_stats("mail_unique + mail_selected", ">=", "mail_deleted")
         self.assert_stats(
             "mail_unique + mail_selected", "in", [
                 "mail_copied", "mail_moved", "mail_deleted"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,9 +133,10 @@ def make_box(tmp_path):
         box.lock()
         for fake_mail in mails:
             box.add(fake_mail.render())
+        dest_box_path = tmp_path.joinpath(uuid4().hex)
 
         box.close()
-        return box._path, box_type
+        return box._path, box_type, str(dest_box_path)
 
     return _make_box
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,7 +30,7 @@ def test_early_export_file_check(invoke, make_box, tmp_path):
 
     See: https://github.com/kdeldycke/mail-deduplicate/issues/119
     """
-    box_path, _ = make_box(Maildir)
+    box_path, _, _ = make_box(Maildir)
 
     result = invoke("--export=non_existing.file", box_path)
     assert result.exit_code == 0

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -53,8 +53,7 @@ def test_invalid_date_parsing_noop(invoke, make_box):
         ],
     )
 
-    result = invoke("--strategy=select-newest",
-                    "--action=delete-selected", box_path)
+    result = invoke("--strategy=select-newest", "--action=delete-selected", box_path)
 
     assert result.exit_code == 0
 

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -42,7 +42,7 @@ def test_invalid_date_parsing_noop(invoke, make_box):
 
     No deduplication happen: mails groups shares the same metadata.
     """
-    box_path, box_type = make_box(
+    box_path, box_type, _ = make_box(
         Maildir,
         [
             invalid_date_mail_1,
@@ -53,7 +53,8 @@ def test_invalid_date_parsing_noop(invoke, make_box):
         ],
     )
 
-    result = invoke("--strategy=select-newest", "--action=delete-selected", box_path)
+    result = invoke("--strategy=select-newest",
+                    "--action=delete-selected", box_path)
 
     assert result.exit_code == 0
 
@@ -74,7 +75,7 @@ def test_invalid_date_parsing_noop(invoke, make_box):
 def test_invalid_date_parsing_dedup(invoke, make_box):
     """Mails with strange non-standard dates gets parsed anyway and deduplicated if we
     reduce the source of hashed headers."""
-    box_path, box_type = make_box(
+    box_path, box_type, _ = make_box(
         Maildir,
         [
             invalid_date_mail_1,

--- a/tests/test_mail_box.py
+++ b/tests/test_mail_box.py
@@ -86,7 +86,7 @@ def test_box_format_definition():
 def test_box_instantiation(make_box, box_format, box_type):
     mail = MailFactory(body="Single mail\n")
 
-    box_path, created_type = make_box(box_type, [mail])
+    box_path, created_type, _ = make_box(box_type, [mail])
 
     assert created_type == box_type
     check_box(box_path, box_type, [mail])
@@ -110,7 +110,7 @@ def test_create_box(make_box, box_type):
     mail1 = MailFactory(body="First mail\n")
     mail2 = MailFactory(body="Second mail\n", message_id="<msg2@test.com>")
 
-    box_path, created_type = make_box(box_type, [mail1, mail2])
+    box_path, created_type, _ = make_box(box_type, [mail1, mail2])
 
     assert created_type == box_type
     check_box(box_path, box_type, [mail1, mail2])
@@ -119,7 +119,7 @@ def test_create_box(make_box, box_type):
 @pytest.mark.parametrize("box_type", (mailbox.Maildir, mailbox.mbox))
 def test_create_empty_box(make_box, box_type):
     """Test creating an empty box."""
-    box_path, created_type = make_box(box_type)
+    box_path, created_type, _ = make_box(box_type)
 
     assert created_type == box_type
     check_box(box_path, box_type, [])
@@ -132,7 +132,7 @@ def test_box_with_duplicate_mails(make_box, box_type):
     mail2 = MailFactory(body="Duplicate content\n", message_id="<dup@test.com>")
     mail3 = MailFactory(body="Unique mail\n", message_id="<unique@test.com>")
 
-    box_path, created_type = make_box(box_type, [mail1, mail2, mail3])
+    box_path, created_type, _ = make_box(box_type, [mail1, mail2, mail3])
 
     assert created_type == box_type
     check_box(box_path, box_type, [mail1, mail2, mail3])
@@ -145,7 +145,7 @@ def test_box_with_different_dates(make_box, box_type):
     mail2 = MailFactory(date="2023-06-15", message_id="<jun@test.com>")
     mail3 = MailFactory(date="2023-12-31", message_id="<dec@test.com>")
 
-    box_path, created_type = make_box(box_type, [mail1, mail2, mail3])
+    box_path, created_type, _ = make_box(box_type, [mail1, mail2, mail3])
 
     assert created_type == box_type
     check_box(box_path, created_type, [mail1, mail2, mail3])
@@ -156,7 +156,7 @@ def test_box_with_single_mail(make_box, box_type):
     """Test boxes with a single mail."""
     mail = MailFactory(body="Single mail\n")
 
-    box_path, created_type = make_box(box_type, [mail])
+    box_path, created_type, _ = make_box(box_type, [mail])
 
     assert created_type == box_type
     check_box(box_path, box_type, [mail])
@@ -171,7 +171,7 @@ def test_box_types_from_fixture(make_box, box_type):
         MailFactory(body="Mail 3\n", message_id="<3@test.com>"),
     ]
 
-    box_path, created_type = make_box(box_type, mails)
+    box_path, created_type, _ = make_box(box_type, mails)
 
     assert created_type == box_type
     check_box(box_path, box_type, mails)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -56,8 +56,10 @@ oldest_mail = MailFactory(date=now.shift(minutes=-3))
 
 
 # Size-based collection of pre-defined fixtures.
-smallest_mail = MailFactory(body="Hello I am a duplicate mail. With annoying ćĥäŖş.")
-smaller_mail = MailFactory(body="Hello I am a duplicate mail. With annoying ćĥäŖş. ++")
+smallest_mail = MailFactory(
+    body="Hello I am a duplicate mail. With annoying ćĥäŖş.")
+smaller_mail = MailFactory(
+    body="Hello I am a duplicate mail. With annoying ćĥäŖş. ++")
 bigger_mail = MailFactory(
     body="Hello I am a duplicate mail. With annoying ćĥäŖş. +++++",
 )
@@ -88,7 +90,7 @@ strategy_options.update(
 @pytest.mark.parametrize(("strategy_id", "params"), strategy_options.items())
 def test_maildir_dry_run(invoke, make_box, strategy_id, params):
     """Check no mail is removed in dry-run mode."""
-    box_path, box_type = make_box(
+    box_path, box_type, _ = make_box(
         Maildir,
         [
             newest_mail,
@@ -420,7 +422,7 @@ def test_maildir_strategy(
     mailbox_results,
 ):
     """Generic test to check the result of a selection strategy."""
-    box_path, box_type = make_box(Maildir, mailbox_input)
+    box_path, box_type, _ = make_box(Maildir, mailbox_input)
 
     result = invoke(f"--strategy={strategy}", "--action=delete-selected", box_path)
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -355,7 +355,6 @@ test_cases = [
             random_mail_1,
             random_mail_2,
             random_mail_2,
-            random_mail_3,
         ],
     ),
     (
@@ -372,7 +371,6 @@ test_cases = [
         [
             random_mail_1,
             random_mail_2,
-            random_mail_3,
         ],
     ),
 ]

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -378,7 +378,7 @@ select_test_cases = [
     # actionable if the selection criterion doesn't produce any match.
     (
         "one_selection",
-        [SELECT_ONE, DISCARD_ALL_BUT_ONE],
+        [Strategy.SELECT_ONE, Strategy.DISCARD_ALL_BUT_ONE],
         [
             random_mail_1,
             random_mail_2,

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -56,10 +56,8 @@ oldest_mail = MailFactory(date=now.shift(minutes=-3))
 
 
 # Size-based collection of pre-defined fixtures.
-smallest_mail = MailFactory(
-    body="Hello I am a duplicate mail. With annoying ćĥäŖş.")
-smaller_mail = MailFactory(
-    body="Hello I am a duplicate mail. With annoying ćĥäŖş. ++")
+smallest_mail = MailFactory(body="Hello I am a duplicate mail. With annoying ćĥäŖş.")
+smaller_mail = MailFactory(body="Hello I am a duplicate mail. With annoying ćĥäŖş. ++")
 bigger_mail = MailFactory(
     body="Hello I am a duplicate mail. With annoying ćĥäŖş. +++++",
 )


### PR DESCRIPTION
#### Summary

This PR fixes/implements the following bugs/features:

- fixes #843
- probably fixes #599

Explain the motivation for making this change. What existing problem does the pull request solve?

The default strategy, `select-one`, ignores non-duplicated emails.

#### Preliminary checks

- [x] I have [read the Code of Conduct](https://github.com/kdeldycke/mail-deduplicate/blob/main/.github/code-of-conduct.md)
- [x] I have referenced above all [issues](https://github.com/kdeldycke/mail-deduplicate/issues) related to the changes I'm bringing
- [x] There is no other [Pull Requests](https://github.com/kdeldycke/mail-deduplicate/pulls) covering the same thing I'm about to address

#### New Features Submissions:

- [x] Does your submission pass tests?

#### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
  - I used a maildir of email {A, B, C, C, C}, and it gives 3 emails in the result, which is as desired
