### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -32,7 +32,7 @@ The list of headers to consider can be set with the `-h`/`--hash-header` option.
 You can still use `Message-ID` as the sole reference header by passing `--hash-header Message-ID --minimal-headers 1` to the CLI.
 ```
 
-### Default headers and mailing lists
+### Default headers and mailing lists {#mailing-lists}
 
 The [default headers](https://kdeldycke.github.io/mail-deduplicate/mail_deduplicate.html#mail_deduplicate.cli.DEFAULT_HASH_HEADERS) used for hashing are currently set to:
 

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ Standalone binaries of `mdedup`'s latest version are available as direct downloa
 > [!WARNING]
 > Performance and memory usage: `mdedup` implementation is quite naive and everything resides in memory.
 >
-> If this is good enough for a volume of a couple of gigabytes, the more emails `mdedup` try to parse, the closer you'll reach the memory limits of your machine. In which case [`mdedup` will exit abruptly](https://github.com/kdeldycke/mail-deduplicate/issues/362#issuecomment-1266743045), zapped by the [OOM killer](https://en.wikipedia.org/wiki/Out_of_memory) of your OS. Of course your mileage may vary depending on your hardware.
+> If this is good enough for a volume of a couple of gigabytes, the more emails `mdedup` try to parse, the closer you'll reach the memory limits of your machine. In which case [`mdedup` will exit abruptly`](https://github.com/kdeldycke/mail-deduplicate/issues/362), zapped by the [OOM killer](https://en.wikipedia.org/wiki/Out_of_memory) of your OS. Of course your mileage may vary depending on your hardware.
 >
 > You can influence implementation of this feature with pull requests, [purchasing business support 🤝](https://github.com/sponsors/kdeldycke) and [sponsorship 🫶](https://github.com/sponsors/kdeldycke).
 


### PR DESCRIPTION
Fixes #899

## Changes

1. **docs/design.md** - Add explicit ID `mailing-lists` to the "Default headers and mailing lists" section
   - This fixes the broken `#mailing-lists` fragment link

2. **readme.md** - Remove non-existent comment fragment from issue link
   - Changed from `#issuecomment-1266743045` to just the issue link
   - The comment fragment was causing a 404 error

## Testing

Both links now resolve correctly without errors