### PR TITLE
Improve error message for minimal headers validation

### DIFF
--- a/mail_deduplicate/cli.py
+++ b/mail_deduplicate/cli.py
@@ -423,7 +423,8 @@ def mdedup(
     if len(hash_header) < minimal_headers:
         raise BadParameter(
             f"Provided number of headers to hash ({len(hash_header)}) is less than "
-            f"the minimal required number of headers ({minimal_headers})."
+            f"the minimal required number of headers ({minimal_headers}). "
+            f"Use -m/--minimal-headers to allow fewer headers."
         )
 
     # Validate exclusive options requirement depending on strategy or action.


### PR DESCRIPTION
## Summary

- Improves the error message when the number of headers provided is less than the minimal required
- Adds a helpful hint to use `-m/--minimal-headers` option

## Context

Fixes #974

Users reported being confused when they got an error saying they need at least 4 headers, without knowing they can adjust this threshold with the `--minimal-headers` option.

Example:
```
$ mdedup -h X-Pm-Gluon-Id ...
Error: Invalid value: Provided number of headers to hash (1) is less than the minimal required number of headers (4).
```

With this change:
```
$ mdedup -h X-Pm-Gluon-Id ...
Error: Invalid value: Provided number of headers to hash (1) is less than the minimal required number of headers (4). Use -m/--minimal-headers to allow fewer headers.
```

## Changes

```diff
- f"the minimal required number of headers ({minimal_headers})."
+ f"the minimal required number of headers ({minimal_headers}). "
+ f"Use -m/--minimal-headers to allow fewer headers."
```

## Testing

The change only affects the error message text, no functional changes.