### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,8 +84,8 @@ jobs:
     # We keep going when a job flagged as not stable fails.
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation. Native extensions with Rust (e.g., test-results-parser from codecov-cli)


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-18` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | [`v6.0.3` → `v7.0.0`](https://github.com/actions/checkout/compare/v6.0.3...v7.0.0) | 2026-06-18 (a month ago) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v8.2.0` → `v8.3.2`](https://github.com/astral-sh/setup-uv/compare/v8.2.0...v8.3.2) | 2026-07-08 (a month ago) |

### Release notes

<details>
<summary><code>actions/checkout</code></summary>

#### [`v6.1.0`](https://github.com/actions/checkout/releases/tag/v6.1.0)

##### What's Changed
* **[BREAKING]** backport `allow-unsafe-pr-checkout` to v6 by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2500
* backport fixes to releases-v6 by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2527

https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/ for more details about this breaking change

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6.0.3...v6.1.0

#### [`v7.0.0`](https://github.com/actions/checkout/releases/tag/v7.0.0)

##### What's Changed
* block checking out fork pr for pull_request_target and workflow_run by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2454
* Bump actions/publish-immutable-action from 0.0.3 to 0.0.4 in the minor-actions-dependencies group across 1 directory by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2458
* Bump flatted from 3.3.1 to 3.4.2 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2460
* Bump js-yaml from 4.1.0 to 4.2.0 by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2461
* Bump @​actions/core and @​actions/tool-cache and Remove uuid by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2459
* upgrade module to esm and update dependencies by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2463
* Bump the minor-npm-dependencies group across 1 directory with 3 updates by @​dependabot[bot] in https://redirect.github.com/actions/checkout/pull/2462
* getting ready for checkout v7 release by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2464
* update error wording by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2467

##### New Contributors
* @​aiqiaoy made their first contribution in https://redirect.github.com/actions/checkout/pull/2454

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v6.0.3...v7.0.0

</details>

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v8.3.1`](https://github.com/astral-sh/setup-uv/releases/tag/v8.3.1)

##### Changes

Just a maintenance release

##### 🧰 Maintenance

- Change update-docs PR labels from 'update-docs' to 'documentation' @​eifinger (#​945)
- chore: update known checksums for 0.11.27 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​944)

##### 📚 Documentation

- docs: update version references to v8.3.0 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​939)

#### [`v8.3.2`](https://github.com/astral-sh/setup-uv/releases/tag/v8.3.2)

##### Changes

Just a maintenance release

##### 🧰 Maintenance

- chore: update known checksums for 0.11.28 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​947)

##### 📚 Documentation

- docs: update version references to v8.3.1 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​946)

##### ⬆️ Dependency updates

- chore: roll up Dependabot updates @​eifinger (#​948)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown window.

| Action | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | `7.0.0` | `7.0.1` | 2026-07-20 (6 days ago) | 2026-07-28 (in 2 days) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | `8.3.2` | `9.0.0` | 2026-07-21 (5 days ago) | 2026-07-29 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`e2ad6d02`](https://github.com/kdeldycke/mail-deduplicate/commit/e2ad6d026a0deeaff9fb61e4067bdcf6923ebf5e)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/e2ad6d026a0deeaff9fb61e4067bdcf6923ebf5e/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/e2ad6d026a0deeaff9fb61e4067bdcf6923ebf5e/.github/workflows/autofix.yaml)
- **Run**: [#872.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/30200664959)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`