### PR TITLE
fix(cli): call `pretty_canonical_headers()` in `--hash-only` mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 > [!WARNING]
 > This version is **not released yet** and is under active development.
 
+- Fix `AttributeError` crash in `-H`/`--hash-only` mode.
 - Add `--jobs` option to parallelize mail hashing.
 - Migrate repository tooling, CI and release automation to [`repomatic`](https://github.com/kdeldycke/repomatic) reusable workflows. Replace Dependabot with Renovate.
 - Adopt the PEP 440 `.devN` development versioning scheme.

--- a/mail_deduplicate/cli.py
+++ b/mail_deduplicate/cli.py
@@ -542,7 +542,7 @@ def mdedup(
         # Print all computed hashes.
         for all_mails in dedup.mails.values():
             for mail in all_mails:
-                echo(mail.pretty_headers)
+                echo(mail.pretty_canonical_headers())
                 echo(f"Hash: {mail.hash_key()}")
 
         # Exit right away.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,20 @@ def test_theme_styles_runtime_output(invoke, make_box, theme_id):
     assert styled_heading in result.stdout
 
 
+def test_hash_only_prints_canonical_headers(invoke, make_box):
+    """``-H/--hash-only`` must print each mail's canonical headers and its hash.
+
+    See: https://github.com/kdeldycke/mail-deduplicate/issues/1004
+    """
+    box_path, _, _ = make_box(Maildir, [MailFactory(message_id="<a@nohost.com>")])
+
+    result = invoke("--action=delete-selected", "--hash-only", box_path)
+    assert result.exit_code == 0
+    assert result.exception is None
+    assert "message-id" in result.stdout.lower()
+    assert "Hash: " in result.stdout
+
+
 def test_cli_test_suite():
     """Run the TOML black-box suite (cli-test-suite.toml) against the installed mdedup.
 


### PR DESCRIPTION
Closes #1004

`-H`/`--hash-only` read `mail.pretty_headers`, which does not exist on `DedupMailMixin` — the renderer is the `pretty_canonical_headers()` method — so the mode aborted on its first mail with `AttributeError: 'MaildirDedupMail' object has no attribute 'pretty_headers'`. Calling the existing method fixes it; a regression test in `tests/test_cli.py` fails on the old line and passes on the new one.
