### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,9 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version >= '3.12' and python_full_version < '3.14'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
+    "python_full_version < '3.14'",
 ]
 
 [options]
@@ -247,101 +245,100 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.12.0"
+version = "7.15.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/26/4a96807b193b011588099c3b5c89fbb05294e5b90e71018e065465f34eb6/coverage-7.12.0.tar.gz", hash = "sha256:fc11e0a4e372cb5f282f16ef90d4a585034050ccda536451901abfb19a57f40c", size = 819341, upload-time = "2025-11-18T13:34:20.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d0/55fe630f4cf94e3fcba868240fad8c8cdd1f764e2a932f8926347e6ec4cd/coverage-7.15.2.tar.gz", hash = "sha256:3df60dc267f0a2ca23cb7a9ab1109c62b9335ffbf519fcfe167157c28c09b81d", size = 927741, upload-time = "2026-07-15T18:56:19.558Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/4a/0dc3de1c172d35abe512332cfdcc43211b6ebce629e4cc42e6cd25ed8f4d/coverage-7.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:32b75c2ba3f324ee37af3ccee5b30458038c50b349ad9b88cee85096132a575b", size = 217409, upload-time = "2025-11-18T13:31:53.122Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c3/086198b98db0109ad4f84241e8e9ea7e5fb2db8c8ffb787162d40c26cc76/coverage-7.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cb2a1b6ab9fe833714a483a915de350abc624a37149649297624c8d57add089c", size = 217927, upload-time = "2025-11-18T13:31:54.458Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/5f/34614dbf5ce0420828fc6c6f915126a0fcb01e25d16cf141bf5361e6aea6/coverage-7.12.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5734b5d913c3755e72f70bf6cc37a0518d4f4745cde760c5d8e12005e62f9832", size = 244678, upload-time = "2025-11-18T13:31:55.805Z" },
-    { url = "https://files.pythonhosted.org/packages/55/7b/6b26fb32e8e4a6989ac1d40c4e132b14556131493b1d06bc0f2be169c357/coverage-7.12.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b527a08cdf15753279b7afb2339a12073620b761d79b81cbe2cdebdb43d90daa", size = 246507, upload-time = "2025-11-18T13:31:57.05Z" },
-    { url = "https://files.pythonhosted.org/packages/06/42/7d70e6603d3260199b90fb48b537ca29ac183d524a65cc31366b2e905fad/coverage-7.12.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bb44c889fb68004e94cab71f6a021ec83eac9aeabdbb5a5a88821ec46e1da73", size = 248366, upload-time = "2025-11-18T13:31:58.362Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/4a/d86b837923878424c72458c5b25e899a3c5ca73e663082a915f5b3c4d749/coverage-7.12.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4b59b501455535e2e5dde5881739897967b272ba25988c89145c12d772810ccb", size = 245366, upload-time = "2025-11-18T13:31:59.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/c2/2adec557e0aa9721875f06ced19730fdb7fc58e31b02b5aa56f2ebe4944d/coverage-7.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d8842f17095b9868a05837b7b1b73495293091bed870e099521ada176aa3e00e", size = 246408, upload-time = "2025-11-18T13:32:00.784Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/4b/8bd1f1148260df11c618e535fdccd1e5aaf646e55b50759006a4f41d8a26/coverage-7.12.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5a6f20bf48b8866095c6820641e7ffbe23f2ac84a2efc218d91235e404c7777", size = 244416, upload-time = "2025-11-18T13:32:01.963Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/3a248dd6a83df90414c54a4e121fd081fb20602ca43955fbe1d60e2312a9/coverage-7.12.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5f3738279524e988d9da2893f307c2093815c623f8d05a8f79e3eff3a7a9e553", size = 244681, upload-time = "2025-11-18T13:32:03.408Z" },
-    { url = "https://files.pythonhosted.org/packages/76/30/aa833827465a5e8c938935f5d91ba055f70516941078a703740aaf1aa41f/coverage-7.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0d68c1f7eabbc8abe582d11fa393ea483caf4f44b0af86881174769f185c94d", size = 245300, upload-time = "2025-11-18T13:32:04.686Z" },
-    { url = "https://files.pythonhosted.org/packages/38/24/f85b3843af1370fb3739fa7571819b71243daa311289b31214fe3e8c9d68/coverage-7.12.0-cp310-cp310-win32.whl", hash = "sha256:7670d860e18b1e3ee5930b17a7d55ae6287ec6e55d9799982aa103a2cc1fa2ef", size = 220008, upload-time = "2025-11-18T13:32:05.806Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/a2/c7da5b9566f7164db9eefa133d17761ecb2c2fde9385d754e5b5c80f710d/coverage-7.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:f999813dddeb2a56aab5841e687b68169da0d3f6fc78ccf50952fa2463746022", size = 220943, upload-time = "2025-11-18T13:32:07.166Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0c/0dfe7f0487477d96432e4815537263363fb6dd7289743a796e8e51eabdf2/coverage-7.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:aa124a3683d2af98bd9d9c2bfa7a5076ca7e5ab09fdb96b81fa7d89376ae928f", size = 217535, upload-time = "2025-11-18T13:32:08.812Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/f5/f9a4a053a5bbff023d3bec259faac8f11a1e5a6479c2ccf586f910d8dac7/coverage-7.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d93fbf446c31c0140208dcd07c5d882029832e8ed7891a39d6d44bd65f2316c3", size = 218044, upload-time = "2025-11-18T13:32:10.329Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c5/84fc3697c1fa10cd8571919bf9693f693b7373278daaf3b73e328d502bc8/coverage-7.12.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:52ca620260bd8cd6027317bdd8b8ba929be1d741764ee765b42c4d79a408601e", size = 248440, upload-time = "2025-11-18T13:32:12.536Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/36/2d93fbf6a04670f3874aed397d5a5371948a076e3249244a9e84fb0e02d6/coverage-7.12.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f3433ffd541380f3a0e423cff0f4926d55b0cc8c1d160fdc3be24a4c03aa65f7", size = 250361, upload-time = "2025-11-18T13:32:13.852Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/49/66dc65cc456a6bfc41ea3d0758c4afeaa4068a2b2931bf83be6894cf1058/coverage-7.12.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7bbb321d4adc9f65e402c677cd1c8e4c2d0105d3ce285b51b4d87f1d5db5245", size = 252472, upload-time = "2025-11-18T13:32:15.068Z" },
-    { url = "https://files.pythonhosted.org/packages/35/1f/ebb8a18dffd406db9fcd4b3ae42254aedcaf612470e8712f12041325930f/coverage-7.12.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22a7aade354a72dff3b59c577bfd18d6945c61f97393bc5fb7bd293a4237024b", size = 248592, upload-time = "2025-11-18T13:32:16.328Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a8/67f213c06e5ea3b3d4980df7dc344d7fea88240b5fe878a5dcbdfe0e2315/coverage-7.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3ff651dcd36d2fea66877cd4a82de478004c59b849945446acb5baf9379a1b64", size = 250167, upload-time = "2025-11-18T13:32:17.687Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/e52aef68154164ea40cc8389c120c314c747fe63a04b013a5782e989b77f/coverage-7.12.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:31b8b2e38391a56e3cea39d22a23faaa7c3fc911751756ef6d2621d2a9daf742", size = 248238, upload-time = "2025-11-18T13:32:19.2Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/a4/4d88750bcf9d6d66f77865e5a05a20e14db44074c25fd22519777cb69025/coverage-7.12.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:297bc2da28440f5ae51c845a47c8175a4db0553a53827886e4fb25c66633000c", size = 247964, upload-time = "2025-11-18T13:32:21.027Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/6b/b74693158899d5b47b0bf6238d2c6722e20ba749f86b74454fac0696bb00/coverage-7.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ff7651cc01a246908eac162a6a86fc0dbab6de1ad165dfb9a1e2ec660b44984", size = 248862, upload-time = "2025-11-18T13:32:22.304Z" },
-    { url = "https://files.pythonhosted.org/packages/18/de/6af6730227ce0e8ade307b1cc4a08e7f51b419a78d02083a86c04ccceb29/coverage-7.12.0-cp311-cp311-win32.whl", hash = "sha256:313672140638b6ddb2c6455ddeda41c6a0b208298034544cfca138978c6baed6", size = 220033, upload-time = "2025-11-18T13:32:23.714Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/a1/e7f63021a7c4fe20994359fcdeae43cbef4a4d0ca36a5a1639feeea5d9e1/coverage-7.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a1783ed5bd0d5938d4435014626568dc7f93e3cb99bc59188cc18857c47aa3c4", size = 220966, upload-time = "2025-11-18T13:32:25.599Z" },
-    { url = "https://files.pythonhosted.org/packages/77/e8/deae26453f37c20c3aa0c4433a1e32cdc169bf415cce223a693117aa3ddd/coverage-7.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:4648158fd8dd9381b5847622df1c90ff314efbfc1df4550092ab6013c238a5fc", size = 219637, upload-time = "2025-11-18T13:32:27.265Z" },
-    { url = "https://files.pythonhosted.org/packages/02/bf/638c0427c0f0d47638242e2438127f3c8ee3cfc06c7fdeb16778ed47f836/coverage-7.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:29644c928772c78512b48e14156b81255000dcfd4817574ff69def189bcb3647", size = 217704, upload-time = "2025-11-18T13:32:28.906Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e1/706fae6692a66c2d6b871a608bbde0da6281903fa0e9f53a39ed441da36a/coverage-7.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8638cbb002eaa5d7c8d04da667813ce1067080b9a91099801a0053086e52b736", size = 218064, upload-time = "2025-11-18T13:32:30.161Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/8b/eb0231d0540f8af3ffda39720ff43cb91926489d01524e68f60e961366e4/coverage-7.12.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:083631eeff5eb9992c923e14b810a179798bb598e6a0dd60586819fc23be6e60", size = 249560, upload-time = "2025-11-18T13:32:31.835Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a1/67fb52af642e974d159b5b379e4d4c59d0ebe1288677fbd04bbffe665a82/coverage-7.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:99d5415c73ca12d558e07776bd957c4222c687b9f1d26fa0e1b57e3598bdcde8", size = 252318, upload-time = "2025-11-18T13:32:33.178Z" },
-    { url = "https://files.pythonhosted.org/packages/41/e5/38228f31b2c7665ebf9bdfdddd7a184d56450755c7e43ac721c11a4b8dab/coverage-7.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e949ebf60c717c3df63adb4a1a366c096c8d7fd8472608cd09359e1bd48ef59f", size = 253403, upload-time = "2025-11-18T13:32:34.45Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/4b/df78e4c8188f9960684267c5a4897836f3f0f20a20c51606ee778a1d9749/coverage-7.12.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6d907ddccbca819afa2cd014bc69983b146cca2735a0b1e6259b2a6c10be1e70", size = 249984, upload-time = "2025-11-18T13:32:35.747Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/51/bb163933d195a345c6f63eab9e55743413d064c291b6220df754075c2769/coverage-7.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b1518ecbad4e6173f4c6e6c4a46e49555ea5679bf3feda5edb1b935c7c44e8a0", size = 251339, upload-time = "2025-11-18T13:32:37.352Z" },
-    { url = "https://files.pythonhosted.org/packages/15/40/c9b29cdb8412c837cdcbc2cfa054547dd83affe6cbbd4ce4fdb92b6ba7d1/coverage-7.12.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51777647a749abdf6f6fd8c7cffab12de68ab93aab15efc72fbbb83036c2a068", size = 249489, upload-time = "2025-11-18T13:32:39.212Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/da/b3131e20ba07a0de4437a50ef3b47840dfabf9293675b0cd5c2c7f66dd61/coverage-7.12.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:42435d46d6461a3b305cdfcad7cdd3248787771f53fe18305548cba474e6523b", size = 249070, upload-time = "2025-11-18T13:32:40.598Z" },
-    { url = "https://files.pythonhosted.org/packages/70/81/b653329b5f6302c08d683ceff6785bc60a34be9ae92a5c7b63ee7ee7acec/coverage-7.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5bcead88c8423e1855e64b8057d0544e33e4080b95b240c2a355334bb7ced937", size = 250929, upload-time = "2025-11-18T13:32:42.915Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/00/250ac3bca9f252a5fb1338b5ad01331ebb7b40223f72bef5b1b2cb03aa64/coverage-7.12.0-cp312-cp312-win32.whl", hash = "sha256:dcbb630ab034e86d2a0f79aefd2be07e583202f41e037602d438c80044957baa", size = 220241, upload-time = "2025-11-18T13:32:44.665Z" },
-    { url = "https://files.pythonhosted.org/packages/64/1c/77e79e76d37ce83302f6c21980b45e09f8aa4551965213a10e62d71ce0ab/coverage-7.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:2fd8354ed5d69775ac42986a691fbf68b4084278710cee9d7c3eaa0c28fa982a", size = 221051, upload-time = "2025-11-18T13:32:46.008Z" },
-    { url = "https://files.pythonhosted.org/packages/31/f5/641b8a25baae564f9e52cac0e2667b123de961985709a004e287ee7663cc/coverage-7.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:737c3814903be30695b2de20d22bcc5428fdae305c61ba44cdc8b3252984c49c", size = 219692, upload-time = "2025-11-18T13:32:47.372Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/14/771700b4048774e48d2c54ed0c674273702713c9ee7acdfede40c2666747/coverage-7.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47324fffca8d8eae7e185b5bb20c14645f23350f870c1649003618ea91a78941", size = 217725, upload-time = "2025-11-18T13:32:49.22Z" },
-    { url = "https://files.pythonhosted.org/packages/17/a7/3aa4144d3bcb719bf67b22d2d51c2d577bf801498c13cb08f64173e80497/coverage-7.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ccf3b2ede91decd2fb53ec73c1f949c3e034129d1e0b07798ff1d02ea0c8fa4a", size = 218098, upload-time = "2025-11-18T13:32:50.78Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/9c/b846bbc774ff81091a12a10203e70562c91ae71badda00c5ae5b613527b1/coverage-7.12.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b365adc70a6936c6b0582dc38746b33b2454148c02349345412c6e743efb646d", size = 249093, upload-time = "2025-11-18T13:32:52.554Z" },
-    { url = "https://files.pythonhosted.org/packages/76/b6/67d7c0e1f400b32c883e9342de4a8c2ae7c1a0b57c5de87622b7262e2309/coverage-7.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bc13baf85cd8a4cfcf4a35c7bc9d795837ad809775f782f697bf630b7e200211", size = 251686, upload-time = "2025-11-18T13:32:54.862Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/75/b095bd4b39d49c3be4bffbb3135fea18a99a431c52dd7513637c0762fecb/coverage-7.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:099d11698385d572ceafb3288a5b80fe1fc58bf665b3f9d362389de488361d3d", size = 252930, upload-time = "2025-11-18T13:32:56.417Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/f3/466f63015c7c80550bead3093aacabf5380c1220a2a93c35d374cae8f762/coverage-7.12.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:473dc45d69694069adb7680c405fb1e81f60b2aff42c81e2f2c3feaf544d878c", size = 249296, upload-time = "2025-11-18T13:32:58.074Z" },
-    { url = "https://files.pythonhosted.org/packages/27/86/eba2209bf2b7e28c68698fc13437519a295b2d228ba9e0ec91673e09fa92/coverage-7.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:583f9adbefd278e9de33c33d6846aa8f5d164fa49b47144180a0e037f0688bb9", size = 251068, upload-time = "2025-11-18T13:32:59.646Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/55/ca8ae7dbba962a3351f18940b359b94c6bafdd7757945fdc79ec9e452dc7/coverage-7.12.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b2089cc445f2dc0af6f801f0d1355c025b76c24481935303cf1af28f636688f0", size = 249034, upload-time = "2025-11-18T13:33:01.481Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/d7/39136149325cad92d420b023b5fd900dabdd1c3a0d1d5f148ef4a8cedef5/coverage-7.12.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:950411f1eb5d579999c5f66c62a40961f126fc71e5e14419f004471957b51508", size = 248853, upload-time = "2025-11-18T13:33:02.935Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/b6/76e1add8b87ef60e00643b0b7f8f7bb73d4bf5249a3be19ebefc5793dd25/coverage-7.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b1aab7302a87bafebfe76b12af681b56ff446dc6f32ed178ff9c092ca776e6bc", size = 250619, upload-time = "2025-11-18T13:33:04.336Z" },
-    { url = "https://files.pythonhosted.org/packages/95/87/924c6dc64f9203f7a3c1832a6a0eee5a8335dbe5f1bdadcc278d6f1b4d74/coverage-7.12.0-cp313-cp313-win32.whl", hash = "sha256:d7e0d0303c13b54db495eb636bc2465b2fb8475d4c8bcec8fe4b5ca454dfbae8", size = 220261, upload-time = "2025-11-18T13:33:06.493Z" },
-    { url = "https://files.pythonhosted.org/packages/91/77/dd4aff9af16ff776bf355a24d87eeb48fc6acde54c907cc1ea89b14a8804/coverage-7.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:ce61969812d6a98a981d147d9ac583a36ac7db7766f2e64a9d4d059c2fe29d07", size = 221072, upload-time = "2025-11-18T13:33:07.926Z" },
-    { url = "https://files.pythonhosted.org/packages/70/49/5c9dc46205fef31b1b226a6e16513193715290584317fd4df91cdaf28b22/coverage-7.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bcec6f47e4cb8a4c2dc91ce507f6eefc6a1b10f58df32cdc61dff65455031dfc", size = 219702, upload-time = "2025-11-18T13:33:09.631Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/62/f87922641c7198667994dd472a91e1d9b829c95d6c29529ceb52132436ad/coverage-7.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:459443346509476170d553035e4a3eed7b860f4fe5242f02de1010501956ce87", size = 218420, upload-time = "2025-11-18T13:33:11.153Z" },
-    { url = "https://files.pythonhosted.org/packages/85/dd/1cc13b2395ef15dbb27d7370a2509b4aee77890a464fb35d72d428f84871/coverage-7.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:04a79245ab2b7a61688958f7a855275997134bc84f4a03bc240cf64ff132abf6", size = 218773, upload-time = "2025-11-18T13:33:12.569Z" },
-    { url = "https://files.pythonhosted.org/packages/74/40/35773cc4bb1e9d4658d4fb669eb4195b3151bef3bbd6f866aba5cd5dac82/coverage-7.12.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09a86acaaa8455f13d6a99221d9654df249b33937b4e212b4e5a822065f12aa7", size = 260078, upload-time = "2025-11-18T13:33:14.037Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/ee/231bb1a6ffc2905e396557585ebc6bdc559e7c66708376d245a1f1d330fc/coverage-7.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:907e0df1b71ba77463687a74149c6122c3f6aac56c2510a5d906b2f368208560", size = 262144, upload-time = "2025-11-18T13:33:15.601Z" },
-    { url = "https://files.pythonhosted.org/packages/28/be/32f4aa9f3bf0b56f3971001b56508352c7753915345d45fab4296a986f01/coverage-7.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b57e2d0ddd5f0582bae5437c04ee71c46cd908e7bc5d4d0391f9a41e812dd12", size = 264574, upload-time = "2025-11-18T13:33:17.354Z" },
-    { url = "https://files.pythonhosted.org/packages/68/7c/00489fcbc2245d13ab12189b977e0cf06ff3351cb98bc6beba8bd68c5902/coverage-7.12.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:58c1c6aa677f3a1411fe6fb28ec3a942e4f665df036a3608816e0847fad23296", size = 259298, upload-time = "2025-11-18T13:33:18.958Z" },
-    { url = "https://files.pythonhosted.org/packages/96/b4/f0760d65d56c3bea95b449e02570d4abd2549dc784bf39a2d4721a2d8ceb/coverage-7.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4c589361263ab2953e3c4cd2a94db94c4ad4a8e572776ecfbad2389c626e4507", size = 262150, upload-time = "2025-11-18T13:33:20.644Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/71/9a9314df00f9326d78c1e5a910f520d599205907432d90d1c1b7a97aa4b1/coverage-7.12.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:91b810a163ccad2e43b1faa11d70d3cf4b6f3d83f9fd5f2df82a32d47b648e0d", size = 259763, upload-time = "2025-11-18T13:33:22.189Z" },
-    { url = "https://files.pythonhosted.org/packages/10/34/01a0aceed13fbdf925876b9a15d50862eb8845454301fe3cdd1df08b2182/coverage-7.12.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:40c867af715f22592e0d0fb533a33a71ec9e0f73a6945f722a0c85c8c1cbe3a2", size = 258653, upload-time = "2025-11-18T13:33:24.239Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/04/81d8fd64928acf1574bbb0181f66901c6c1c6279c8ccf5f84259d2c68ae9/coverage-7.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:68b0d0a2d84f333de875666259dadf28cc67858bc8fd8b3f1eae84d3c2bec455", size = 260856, upload-time = "2025-11-18T13:33:26.365Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/76/fa2a37bfaeaf1f766a2d2360a25a5297d4fb567098112f6517475eee120b/coverage-7.12.0-cp313-cp313t-win32.whl", hash = "sha256:73f9e7fbd51a221818fd11b7090eaa835a353ddd59c236c57b2199486b116c6d", size = 220936, upload-time = "2025-11-18T13:33:28.165Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/52/60f64d932d555102611c366afb0eb434b34266b1d9266fc2fe18ab641c47/coverage-7.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:24cff9d1f5743f67db7ba46ff284018a6e9aeb649b67aa1e70c396aa1b7cb23c", size = 222001, upload-time = "2025-11-18T13:33:29.656Z" },
-    { url = "https://files.pythonhosted.org/packages/77/df/c303164154a5a3aea7472bf323b7c857fed93b26618ed9fc5c2955566bb0/coverage-7.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c87395744f5c77c866d0f5a43d97cc39e17c7f1cb0115e54a2fe67ca75c5d14d", size = 220273, upload-time = "2025-11-18T13:33:31.415Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/2e/fc12db0883478d6e12bbd62d481210f0c8daf036102aa11434a0c5755825/coverage-7.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a1c59b7dc169809a88b21a936eccf71c3895a78f5592051b1af8f4d59c2b4f92", size = 217777, upload-time = "2025-11-18T13:33:32.86Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/c1/ce3e525d223350c6ec16b9be8a057623f54226ef7f4c2fee361ebb6a02b8/coverage-7.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8787b0f982e020adb732b9f051f3e49dd5054cebbc3f3432061278512a2b1360", size = 218100, upload-time = "2025-11-18T13:33:34.532Z" },
-    { url = "https://files.pythonhosted.org/packages/15/87/113757441504aee3808cb422990ed7c8bcc2d53a6779c66c5adef0942939/coverage-7.12.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5ea5a9f7dc8877455b13dd1effd3202e0bca72f6f3ab09f9036b1bcf728f69ac", size = 249151, upload-time = "2025-11-18T13:33:36.135Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/1d/9529d9bd44049b6b05bb319c03a3a7e4b0a8a802d28fa348ad407e10706d/coverage-7.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fdba9f15849534594f60b47c9a30bc70409b54947319a7c4fd0e8e3d8d2f355d", size = 251667, upload-time = "2025-11-18T13:33:37.996Z" },
-    { url = "https://files.pythonhosted.org/packages/11/bb/567e751c41e9c03dc29d3ce74b8c89a1e3396313e34f255a2a2e8b9ebb56/coverage-7.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a00594770eb715854fb1c57e0dea08cce6720cfbc531accdb9850d7c7770396c", size = 253003, upload-time = "2025-11-18T13:33:39.553Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b3/c2cce2d8526a02fb9e9ca14a263ca6fc074449b33a6afa4892838c903528/coverage-7.12.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5560c7e0d82b42eb1951e4f68f071f8017c824ebfd5a6ebe42c60ac16c6c2434", size = 249185, upload-time = "2025-11-18T13:33:42.086Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/a7/967f93bb66e82c9113c66a8d0b65ecf72fc865adfba5a145f50c7af7e58d/coverage-7.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d6c2e26b481c9159c2773a37947a9718cfdc58893029cdfb177531793e375cfc", size = 251025, upload-time = "2025-11-18T13:33:43.634Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/b2/f2f6f56337bc1af465d5b2dc1ee7ee2141b8b9272f3bf6213fcbc309a836/coverage-7.12.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:6e1a8c066dabcde56d5d9fed6a66bc19a2883a3fe051f0c397a41fc42aedd4cc", size = 248979, upload-time = "2025-11-18T13:33:46.04Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/7a/bf4209f45a4aec09d10a01a57313a46c0e0e8f4c55ff2965467d41a92036/coverage-7.12.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f7ba9da4726e446d8dd8aae5a6cd872511184a5d861de80a86ef970b5dacce3e", size = 248800, upload-time = "2025-11-18T13:33:47.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/b7/1e01b8696fb0521810f60c5bbebf699100d6754183e6cc0679bf2ed76531/coverage-7.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e0f483ab4f749039894abaf80c2f9e7ed77bbf3c737517fb88c8e8e305896a17", size = 250460, upload-time = "2025-11-18T13:33:49.537Z" },
-    { url = "https://files.pythonhosted.org/packages/71/ae/84324fb9cb46c024760e706353d9b771a81b398d117d8c1fe010391c186f/coverage-7.12.0-cp314-cp314-win32.whl", hash = "sha256:76336c19a9ef4a94b2f8dc79f8ac2da3f193f625bb5d6f51a328cd19bfc19933", size = 220533, upload-time = "2025-11-18T13:33:51.16Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/71/1033629deb8460a8f97f83e6ac4ca3b93952e2b6f826056684df8275e015/coverage-7.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7c1059b600aec6ef090721f8f633f60ed70afaffe8ecab85b59df748f24b31fe", size = 221348, upload-time = "2025-11-18T13:33:52.776Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/5f/ac8107a902f623b0c251abdb749be282dc2ab61854a8a4fcf49e276fce2f/coverage-7.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:172cf3a34bfef42611963e2b661302a8931f44df31629e5b1050567d6b90287d", size = 219922, upload-time = "2025-11-18T13:33:54.316Z" },
-    { url = "https://files.pythonhosted.org/packages/79/6e/f27af2d4da367f16077d21ef6fe796c874408219fa6dd3f3efe7751bd910/coverage-7.12.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:aa7d48520a32cb21c7a9b31f81799e8eaec7239db36c3b670be0fa2403828d1d", size = 218511, upload-time = "2025-11-18T13:33:56.343Z" },
-    { url = "https://files.pythonhosted.org/packages/67/dd/65fd874aa460c30da78f9d259400d8e6a4ef457d61ab052fd248f0050558/coverage-7.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:90d58ac63bc85e0fb919f14d09d6caa63f35a5512a2205284b7816cafd21bb03", size = 218771, upload-time = "2025-11-18T13:33:57.966Z" },
-    { url = "https://files.pythonhosted.org/packages/55/e0/7c6b71d327d8068cb79c05f8f45bf1b6145f7a0de23bbebe63578fe5240a/coverage-7.12.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ca8ecfa283764fdda3eae1bdb6afe58bf78c2c3ec2b2edcb05a671f0bba7b3f9", size = 260151, upload-time = "2025-11-18T13:33:59.597Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ce/4697457d58285b7200de6b46d606ea71066c6e674571a946a6ea908fb588/coverage-7.12.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:874fe69a0785d96bd066059cd4368022cebbec1a8958f224f0016979183916e6", size = 262257, upload-time = "2025-11-18T13:34:01.166Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/33/acbc6e447aee4ceba88c15528dbe04a35fb4d67b59d393d2e0d6f1e242c1/coverage-7.12.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b3c889c0b8b283a24d721a9eabc8ccafcfc3aebf167e4cd0d0e23bf8ec4e339", size = 264671, upload-time = "2025-11-18T13:34:02.795Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ec/e2822a795c1ed44d569980097be839c5e734d4c0c1119ef8e0a073496a30/coverage-7.12.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bb5b894b3ec09dcd6d3743229dc7f2c42ef7787dc40596ae04c0edda487371e", size = 259231, upload-time = "2025-11-18T13:34:04.397Z" },
-    { url = "https://files.pythonhosted.org/packages/72/c5/a7ec5395bb4a49c9b7ad97e63f0c92f6bf4a9e006b1393555a02dae75f16/coverage-7.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:79a44421cd5fba96aa57b5e3b5a4d3274c449d4c622e8f76882d76635501fd13", size = 262137, upload-time = "2025-11-18T13:34:06.068Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0c/02c08858b764129f4ecb8e316684272972e60777ae986f3865b10940bdd6/coverage-7.12.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:33baadc0efd5c7294f436a632566ccc1f72c867f82833eb59820ee37dc811c6f", size = 259745, upload-time = "2025-11-18T13:34:08.04Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/04/4fd32b7084505f3829a8fe45c1a74a7a728cb251aaadbe3bec04abcef06d/coverage-7.12.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c406a71f544800ef7e9e0000af706b88465f3573ae8b8de37e5f96c59f689ad1", size = 258570, upload-time = "2025-11-18T13:34:09.676Z" },
-    { url = "https://files.pythonhosted.org/packages/48/35/2365e37c90df4f5342c4fa202223744119fe31264ee2924f09f074ea9b6d/coverage-7.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e71bba6a40883b00c6d571599b4627f50c360b3d0d02bfc658168936be74027b", size = 260899, upload-time = "2025-11-18T13:34:11.259Z" },
-    { url = "https://files.pythonhosted.org/packages/05/56/26ab0464ca733fa325e8e71455c58c1c374ce30f7c04cebb88eabb037b18/coverage-7.12.0-cp314-cp314t-win32.whl", hash = "sha256:9157a5e233c40ce6613dead4c131a006adfda70e557b6856b97aceed01b0e27a", size = 221313, upload-time = "2025-11-18T13:34:12.863Z" },
-    { url = "https://files.pythonhosted.org/packages/da/1c/017a3e1113ed34d998b27d2c6dba08a9e7cb97d362f0ec988fcd873dcf81/coverage-7.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e84da3a0fd233aeec797b981c51af1cabac74f9bd67be42458365b30d11b5291", size = 222423, upload-time = "2025-11-18T13:34:15.14Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/36/bcc504fdd5169301b52568802bb1b9cdde2e27a01d39fbb3b4b508ab7c2c/coverage-7.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:01d24af36fedda51c2b1aca56e4330a3710f83b02a5ff3743a6b015ffa7c9384", size = 220459, upload-time = "2025-11-18T13:34:17.222Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/a3/43b749004e3c09452e39bb56347a008f0a0668aad37324a99b5c8ca91d9e/coverage-7.12.0-py3-none-any.whl", hash = "sha256:159d50c0b12e060b15ed3d39f87ed43d4f7f7ad40b8a534f4dd331adbb51104a", size = 209503, upload-time = "2025-11-18T13:34:18.892Z" },
+    { url = "https://files.pythonhosted.org/packages/10/03/060ce69008ac97bbc01b1411b3e55b61f6f015659400b46749b662107831/coverage-7.15.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b5bd92ff1ec22e535eab0de75fa6db021992791f461a2aceb7822c625a1187d", size = 221284, upload-time = "2026-07-15T18:53:29.52Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a3/d936e8b53edd9684100a6aefaf3fcabaa54728fe33324436c8d279c047aa/coverage-7.15.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:44826758cfe73fcd0e6af5deb4ba6d5417cc1d13df3acb35c93484a11160f846", size = 221799, upload-time = "2026-07-15T18:53:31.708Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a3/ca234b06aec7ee28226f11d39a696b4481fe5eddfce8e03bf39979bb8ffb/coverage-7.15.2-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:09f5c6ec5901f667bd97dd140b5b9a2586b10efec66f46fb1e6d8135f8b95bdf", size = 248544, upload-time = "2026-07-15T18:53:33.212Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/89/dda79527bb7573ba91828b2fb91b3105d87378d6a2749ca0c0924ce0addd/coverage-7.15.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1d16e3a7104ea84f03e614611b3edbf6fb6892554b3ab0fe7fbb3f2b2ef04376", size = 250374, upload-time = "2026-07-15T18:53:34.683Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c6/c33755a34572f81f49a8c0cdf6b622f35ccb3238b136e1909daf0cdd4319/coverage-7.15.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d46e62cb35d91e6e2589fda6d28074426b0e276422b5d2ebef2c6b11dc60dbfd", size = 252239, upload-time = "2026-07-15T18:53:36.205Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6f/dc341741b375be53a5baeee5b4bf0f0e525d38caed428f7932d23bb7bcb1/coverage-7.15.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dfd3db045e95960ae3683059571e597fda7cc610106a8916f77c5839048c1deb", size = 254150, upload-time = "2026-07-15T18:53:37.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/8d/966a18a5b195cb4e77b14c53f5f3dce22b5da05e6de7fafd1e08f2d2067a/coverage-7.15.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:affd532502d34c0472d0cdb181325c89f1d2c44992fef0c17e88e7b1576259a1", size = 249234, upload-time = "2026-07-15T18:53:39.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/8b2e367496ab48484d48e79984fec76cdc1b7cb5d3a00ee799a5602e3ec9/coverage-7.15.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d17d7512151fedfcc64c1821a8977fc9be0dbf495754669afcab7b57abc98ae9", size = 250276, upload-time = "2026-07-15T18:53:41.027Z" },
+    { url = "https://files.pythonhosted.org/packages/63/92/1199318a200eb6c8c6ce0192c892c8710ac791abbe0f35099294620bbfda/coverage-7.15.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e26ff680768b8095e8874aabe0e9d3a47a2a9f176a8340d05f8604c56457c23a", size = 248283, upload-time = "2026-07-15T18:53:42.557Z" },
+    { url = "https://files.pythonhosted.org/packages/56/da/be284a55c5619bda891a89c27dfd59324a2c6a14d755cf6aac6960ceebeb/coverage-7.15.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:7e8f27131dc7cd53de2c137dd207b3720919320b3c20d499dc30aa9ee6173287", size = 252093, upload-time = "2026-07-15T18:53:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/53/ee112da833ddd77b73c6d781a98029b45b584b136615b4900ed0569f887e/coverage-7.15.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:728a33676d4c3f0db977990a4bd421dcaa3be3e53b5b6273036fff6666008e89", size = 248552, upload-time = "2026-07-15T18:53:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/82/6a/802cfc802e9113494c80bf3f284cd4d72faeb1f24e244f61046af364f2ca/coverage-7.15.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:29c052f7c83ccfcc5c577eaae025d2e4a9bb80daf03c0ac31c996e83b000ce88", size = 249154, upload-time = "2026-07-15T18:53:47.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/65/529808e91d651147edae408fd9e894abc3b8cad7f3e594bbc36719a3e13a/coverage-7.15.2-cp310-cp310-win32.whl", hash = "sha256:1268ac8fb9ddcd783d3948dbabaf80a5d53bfdaa0575e873e2139a692f797443", size = 223334, upload-time = "2026-07-15T18:53:48.768Z" },
+    { url = "https://files.pythonhosted.org/packages/68/0f/0e1829d7001130876dfbc0b4e1c737ea7c155b809e3e4a98a0aa268e2369/coverage-7.15.2-cp310-cp310-win_amd64.whl", hash = "sha256:9f4432898c4bf2fba0435bbe35dd4437d7264565e5a88a21f5b49d8662a6b629", size = 223959, upload-time = "2026-07-15T18:53:50.429Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/3a/54536704f507d4573bf9161c4d0dd3dd59b6d85e48c664e901b6844d8e33/coverage-7.15.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2f1ec6f304b156669cfde653b4e9a953f5de87e247ea02ac599bce0ab2744036", size = 221414, upload-time = "2026-07-15T18:53:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/8ba925d29743e3577b21e4d8c11a702b76bc93c41e7fdfd1177af63d4b8d/coverage-7.15.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d3361879d736f469f45723c11ea1a5bbdaf1f6928f0e632c940378b5aa9b660", size = 221913, upload-time = "2026-07-15T18:53:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/54/a855f3aa0187f2b431ade4e4791b77b56282cfb5d201c83ec26a31b5b36a/coverage-7.15.2-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c6a98d698f9e2c8008d0370ec7fc452ebfcc530002ae2d0061170d768b992589", size = 252332, upload-time = "2026-07-15T18:53:55.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d3/13ac97b4370640ba3452fc8559b06cc2f479ce3ba4a0b632a73e44c38a7d/coverage-7.15.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d50dd325e18ec25bfcc10cd7f99b04df1ab9ec76b0918c260e60817ad0643dee", size = 254243, upload-time = "2026-07-15T18:53:57.055Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/5eca144942d8d0659d3f55176517f4a59cdc65eefd17146a0770935a3ebd/coverage-7.15.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:67d7602480a47bdf5b675635403625553ebaa70d5a62a657c035149fd401cea0", size = 256352, upload-time = "2026-07-15T18:53:58.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ba/d3db2e01a50fc88cdb4c0f19542bcf6f61489e34dc9aa3538413e2459a38/coverage-7.15.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cee0f89f4767a6057c8fbf168f8135f18be651300496086bd873e3189fed0487", size = 258313, upload-time = "2026-07-15T18:54:00.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b3/aba83416e9177df28e5186d856c19158c59fc0e7e814aaa61a4a2354ad1b/coverage-7.15.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a29ec5305a7335aacee2d799e3422e91e1c8a12474986e2b3b07e315c91be82f", size = 252449, upload-time = "2026-07-15T18:54:02.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/a5/4b00ecac0194431ab451b0f6710f8e2517d04cef60f821b14dec4637d575/coverage-7.15.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:48ccc6395958eda89093ecdc35644c86f23a8b23a7f4d44958812b721aad67c1", size = 254043, upload-time = "2026-07-15T18:54:04.072Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b6/cfa209b4313ee7f1b34da47efcd789ea51c024ad35af390e00f5a3c10a2e/coverage-7.15.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:81f382c5a94b434ec1f6da607edb904c76d7212e618cd4d1bc9f97bed4120ef5", size = 252107, upload-time = "2026-07-15T18:54:06.745Z" },
+    { url = "https://files.pythonhosted.org/packages/36/67/e8cac5a6954038c98d7fe7eb9802afe7ab3ecb637bb7cc00e69b4148b56d/coverage-7.15.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bbc808daf4f5cd567af8075ecc72d21c6dfef9a254709a621a84c217c935ebc0", size = 255873, upload-time = "2026-07-15T18:54:08.48Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/92/395cca9f330a86c3fe3471d73e2c102116c4c58fdc619dbbc125c6e93a54/coverage-7.15.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a4c46b247b5d4b78f613bd89fea926d32b25c6cc61a50bd1e99ba310348f3dad", size = 251826, upload-time = "2026-07-15T18:54:10.083Z" },
+    { url = "https://files.pythonhosted.org/packages/51/60/3e91b20295439652424f426b7086ec5bf4fbe3f604c73eda22b986c4fd6b/coverage-7.15.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:094dd37f3ef7b2da8b068b583d1f4c40f91c65197e16c52a71962d5d537fc5db", size = 252735, upload-time = "2026-07-15T18:54:11.878Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/8c07839005e5e3c6b3877d3a6e2a80ce766589f31dd2b6882b78d59a7b8c/coverage-7.15.2-cp311-cp311-win32.whl", hash = "sha256:a63b9e190711134d581c4d703df5df09851b1acf99792c7aacbbe9f41f0283c9", size = 223500, upload-time = "2026-07-15T18:54:13.525Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/98/59d83c257cd59f0fbaf9d9ddb26b744a576760dfd1ae16e516408894a02b/coverage-7.15.2-cp311-cp311-win_amd64.whl", hash = "sha256:8bb9f4b4279187560796a4cdaca3b0a93dd97e48ee667df005f4ed9a97403688", size = 223973, upload-time = "2026-07-15T18:54:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/09/2d285c8bef5c4f695d120c1c96dc11715638aa8e134069f210bb6a62a9fe/coverage-7.15.2-cp311-cp311-win_arm64.whl", hash = "sha256:8c726b232659cbd2ae57ade46509eb068c9bd7a06df9fcbff6fe484870006934", size = 223519, upload-time = "2026-07-15T18:54:16.803Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/50/eb5bf42e531611a9f8d272556b1ed4de503f84a91413584094487cf69f8f/coverage-7.15.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1adac78e5abc7c5438f7a209c9ca69d06542f0bf481d728b6989ea80b813fdf9", size = 221587, upload-time = "2026-07-15T18:54:18.439Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d1/da99af464c335d4e023a6efcd7ec30f63b88a43c93745154ab74ffb31cea/coverage-7.15.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b868acc62aa5de3be7a9d05c2333bf8359ca987e43f9cb30ff8fbda6a024ab73", size = 221943, upload-time = "2026-07-15T18:54:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8a/13c42723d61ca447eafa18732e8141dd6a63f2732e1c7e1502c182dd88d7/coverage-7.15.2-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6f6966fc30e6f06ca8f98fb0ce51eda6b111b3ee8d066a8b1ec9e77fa06ab55d", size = 253450, upload-time = "2026-07-15T18:54:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/29/99021303f98fbdcb63504b4d07bea4cc025b9b2dd907c4f07c85d50a0dab/coverage-7.15.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:68af907f595ab01a78f794932ff3bdf929c316d3000810d38dbc247129e26f8b", size = 256187, upload-time = "2026-07-15T18:54:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a8/fd503715ed6ca9c5d742923aa5209257340b367a867b2ced0c7d4ba8a0b9/coverage-7.15.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:afa29e2eff3d5729267e2cb2fd4ce9d61c952932fb2694e34ccb5d9540c6a296", size = 257301, upload-time = "2026-07-15T18:54:25.183Z" },
+    { url = "https://files.pythonhosted.org/packages/da/40/3f4b8fb409810036ebc2857d36adc0498c6e957b5df0290c5036b2e143f1/coverage-7.15.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bbf44513ceb1589e31948e20eafbde9deaface90e1a1afa5f5f77b4423d17ce6", size = 259562, upload-time = "2026-07-15T18:54:27.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8a/9bdffbef47db77cce3d6b02a28f7e919b19f0106c4b080c2c2246040f885/coverage-7.15.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9deddf09eecb717b7f980414b43d90a5b22ff3967d2949ab29cb0aa83d9e9098", size = 253841, upload-time = "2026-07-15T18:54:29.134Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1e/9031efde019d31a06646261fce6dfc5c3c74e951e27a71e5c9a424563178/coverage-7.15.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ae901f7e55ba405c84ee1cab3d3e962e4e871e4a2bcb9c90911adbd69b42ac5a", size = 255221, upload-time = "2026-07-15T18:54:31.142Z" },
+    { url = "https://files.pythonhosted.org/packages/56/db/787acde872389fc84a9ef9d8cd1ccc658e391ab4cb5b28092a714426a394/coverage-7.15.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a0f47002c6eeb7c280228467a4cb0cc15ca2103a8421b986b2d3ec04a0f9bd8b", size = 253366, upload-time = "2026-07-15T18:54:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9b/6f57bc4b93c842eef1695f8cdaf2318e35e7ba54f5ba80d84be213ab7858/coverage-7.15.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1cd7a5beb7af3e864a13b1f0fb26efd3695da43ef0daf71e586adfffaf34d5b2", size = 257434, upload-time = "2026-07-15T18:54:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/88/26/b3186a21b2acc83e451118978905c81c7072c3333707804db09a78c096a2/coverage-7.15.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:97a5c5457a9fb1d6c4e06cfb5dc835871fbfb6a6a51addc9e925bdeff5ef7440", size = 252935, upload-time = "2026-07-15T18:54:36.548Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/c9f3376b2e717ea69ed7a6e9a5fcab968fb0b290db6cf4bd9a1fc7541b75/coverage-7.15.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0901cfe6c13bcd2302da4f83e884555d2a22bda6e4c476f09ef204ba20ca536e", size = 254807, upload-time = "2026-07-15T18:54:38.296Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e1/dfc15401f4a8aaeb486e1ba3e9e3c40522a6e38bd0ecf0b3f29cb8082957/coverage-7.15.2-cp312-cp312-win32.whl", hash = "sha256:b171bdd71cb7ff792bf32e376173b0ace7e7963e7e57c58dfc42063a6a7174cd", size = 223641, upload-time = "2026-07-15T18:54:40.103Z" },
+    { url = "https://files.pythonhosted.org/packages/91/40/81b6d809d320cd366ec5bdf8176575e897dcb8efe7fb4b489ef9e93e4d13/coverage-7.15.2-cp312-cp312-win_amd64.whl", hash = "sha256:582edc45c2040543fef83341be23c43024a3ab3ae0c2d8bc498a06282905ad40", size = 224172, upload-time = "2026-07-15T18:54:41.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/28/9f14ec438149f7de557f45518f09b4a7917b795cc37083aa7db482693f8c/coverage-7.15.2-cp312-cp312-win_arm64.whl", hash = "sha256:a638db90c61cd219aeee65e83a24fdaa57269a741ae0cf773309208ac862cee3", size = 223556, upload-time = "2026-07-15T18:54:43.674Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d5/f8c838e6b7282976f7c918884b792df7a0c42c5bba5d99c60ad2d221d56d/coverage-7.15.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1121caa19159a38b5463eaae4b1e1fde81e525b15ecc5e000cd5b1a108f743a8", size = 221606, upload-time = "2026-07-15T18:54:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/97c926376364f66298cc44893b89cdf17b8bc406376497c4061ae4b8a8ff/coverage-7.15.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a300c6934e0989c327b9e8a1e110329da4641149f872bbe9f70168be66da76c1", size = 221982, upload-time = "2026-07-15T18:54:47.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/30/a36050a6e83c2135ee0776f452ca3948224befc6d7f26acecc082d0c106a/coverage-7.15.2-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2617f8799d268fabdeef42a7e89ac3a23e1deee9025427db2df970f99a89a578", size = 252972, upload-time = "2026-07-15T18:54:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/06b5f1daf95f0f15ab05bd75f26ba5f3c8b33d0bb72f3aaa3cf41d1bad3a/coverage-7.15.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7dc2950a2992cd676d35c20ae63522836deeb034f08874699d14068710af3dc1", size = 255569, upload-time = "2026-07-15T18:54:51.098Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1c/9afb3f8de2b8d36960391c48559a2e3ff96594b58099f115921549ea8d0d/coverage-7.15.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e36686f7a442185db2400b3df171aac520869faf9deb59df687d28659eda2a6", size = 256806, upload-time = "2026-07-15T18:54:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d8/b989f96061a5e32d82fddd1b1b9ff48a7c8f8ae7606f0e80fd9de54b1e33/coverage-7.15.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7d29ca7bd67af6e12e74632d65f026eabc1364da5c254494cd914446a28a3ef7", size = 258936, upload-time = "2026-07-15T18:54:55.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fa/f99771f5110457c7b511c1935ca49ddf288218eaa84322e028b9334146ae/coverage-7.15.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:db9c8438057e5b0f6a22a0af99c0c1d26b57fbbdbd1be5861ddb8f897fcc3a2d", size = 253178, upload-time = "2026-07-15T18:54:57.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/96/c098a6044d119c751ceede7be91035fa8310170ec24a6523aff72f0a5793/coverage-7.15.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:63022c4c8dec1d0342f05c3ede99842fe3d007689acc45e86f123a1746e4a026", size = 254934, upload-time = "2026-07-15T18:54:59.41Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a2/1457b3a7a50c8d77500103b97a046db863e2f59a1cf6d2f814595f349885/coverage-7.15.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6c0be82b4d4aa5b2704e08518e2252f3e3d110164bcca826816801052e48a7aa", size = 252898, upload-time = "2026-07-15T18:55:01.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0e/76958874c471ecfcdde0d2b2747bb2c61bdbf34a40636f4ce9db9923e643/coverage-7.15.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4510fb9cdf6bb02dfa6af0be4a534b8102d086e22e4a33f8836df663da3d660d", size = 257056, upload-time = "2026-07-15T18:55:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/7c/3d7c4e3bf58baa40327dc7edc2272b17cf02299366d52763db1b0ca1556a/coverage-7.15.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:42ec3d989421b174a2ab607c1539f24127ad362757b7f1c0c0d7a2993f7eb37b", size = 252718, upload-time = "2026-07-15T18:55:05.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b8/1cecffed9ce14fb25be9ba42d37b6bb61485c9a3ddd43cd3dde36b6087d8/coverage-7.15.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e8f91bce78e32343af184c3b7fa28fcf5a9e2641f4b6623d392038f804939188", size = 254490, upload-time = "2026-07-15T18:55:06.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2c/42984561bc7f4c045dca67516a0c50ee5ef8d84352dbeb5559dc86c4823e/coverage-7.15.2-cp313-cp313-win32.whl", hash = "sha256:434e68d531858205895eb0d74b73d20b84260de426387d53c422a5acda2cf050", size = 223647, upload-time = "2026-07-15T18:55:08.941Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9f/39c7c9245efc583beddf89a87683574e663ed93637f3afb6cd7b88405676/coverage-7.15.2-cp313-cp313-win_amd64.whl", hash = "sha256:26c3b04a6377fd7c09800921fa934e3a17c0020439cd59df73e73ae1d4b6a78c", size = 224190, upload-time = "2026-07-15T18:55:10.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/de/3a2883cf8a213659280ef4b403059e17a9acaeb7fc7fd4105e1226ff2e6d/coverage-7.15.2-cp313-cp313-win_arm64.whl", hash = "sha256:3ed010aa1b69cda8e827aabfca9866216c980e2dca82ab9a78c5f83689964c8b", size = 223583, upload-time = "2026-07-15T18:55:12.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5f/aed265fd7a3551a394f36dfe41868aee709b7f95db4052205b4ad1563ac3/coverage-7.15.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f633c5c5fc783732f6312280122e859538fa24461235597c13d803ea9a108a", size = 221650, upload-time = "2026-07-15T18:55:14.527Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/2c/222ba12a545189017120f8eddfc1a0bd4616b47d5d4a8d99421edb2fe4c6/coverage-7.15.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:075560438765b7a2ef43bf7aa7758661b53d889df47f062a31bda6c1ade553a2", size = 221988, upload-time = "2026-07-15T18:55:16.674Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/38/304b5877ab46e6c290b4292cfcf3fe28245f0e5597cad7f6acc91fc7e0a4/coverage-7.15.2-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:25fd15dd40a0a2c51a500d664ca29053c09c3259d998407bf982b6e114696138", size = 253029, upload-time = "2026-07-15T18:55:18.856Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/58/821b533b8db9e44cf1d8a97bd525149ced40dde1d0093da02cb78e715244/coverage-7.15.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9a6367e4aff723e8ee8190836836124284e8fcd4265e307c844010cfa074f3f", size = 255536, upload-time = "2026-07-15T18:55:21.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f2/7aa06604c389d32ea7f0a6a988359a7eafc3cd3f8e7bc2e88cd2fdf0b877/coverage-7.15.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9854ca62c152874b2060772503535be2e8f53f70b8aaa7686b094888d872f984", size = 256881, upload-time = "2026-07-15T18:55:23.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4f/1ef342339c7916d0096bc5888cc0f653882cc7bc8f897d5cb89143287c9b/coverage-7.15.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:913b6c56e110da40e035bbd168353bf7aaa2544a5eaccea5d98a4629aac156c7", size = 259196, upload-time = "2026-07-15T18:55:25.099Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f4/7ed055d7a9c5ec13b161773a115a5ccc6b0081d568c31fad830806306cc7/coverage-7.15.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aaccad4129d735a8a4d526f26929894c9a4e8ef7034566f210b176749d6906e3", size = 253036, upload-time = "2026-07-15T18:55:27.018Z" },
+    { url = "https://files.pythonhosted.org/packages/14/79/ea82cca18c242a3a38b6c017da39726aa62dcb64aa635abf79b92009975c/coverage-7.15.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a164b50081fc7357331c4024ef4d17b78ba325f8380d05f5a69599a7e05257ee", size = 254887, upload-time = "2026-07-15T18:55:29.084Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ba/a136db3c0d9562b00e10b72540dbf3a33cd3bc5b95060c9308e247494623/coverage-7.15.2-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:bfd341ccf78128e72c094bc70cc25b3ef309c33c7c2c66ba3ed4309549e02de1", size = 252852, upload-time = "2026-07-15T18:55:31.184Z" },
+    { url = "https://files.pythonhosted.org/packages/17/17/ea334246b16b7d059953fad6fdefa11e33c68efbd3fe37b1098120a1fac2/coverage-7.15.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:1473b3ba8e7ee0f076117b1a72c23f579a2b9e2bb742f48a8d86ea27ca93f91a", size = 257128, upload-time = "2026-07-15T18:55:33.163Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c3/074fb66d46d607855f710876b117cbda562c5ab08363528e78820449f937/coverage-7.15.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:17c432b5f73ad52ef46fb06019f6fa7c66ce381961cf0f7dfd1d3a4bd3a98145", size = 252668, upload-time = "2026-07-15T18:55:35.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c1/f620850ada9b36435921c9a3a8057013422b1d964eb4bf37fe138724d192/coverage-7.15.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:77f0ef5011df53a4bd1b35211ab122287f8d9b8d7aa1c4553e5c2deb24b1d446", size = 254325, upload-time = "2026-07-15T18:55:37.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/31/a729ca3689404493af82ef8e6ff70bd88bdda8da89aeef6ca9b387aeb2b4/coverage-7.15.2-cp314-cp314-win32.whl", hash = "sha256:f653e5d7248c1191ec988a85c72edeab46c3ff44f90639a4ed4874ec0be90243", size = 223844, upload-time = "2026-07-15T18:55:39.078Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/83/5d809dc808fb1698c671f3e372259bb9158e64b7ea526fc6ab7de64de9fe/coverage-7.15.2-cp314-cp314-win_amd64.whl", hash = "sha256:9911f31aad8906abe337c271343485cf20df5e70df5d2f57f9f136e7b55f26bc", size = 224331, upload-time = "2026-07-15T18:55:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/16/4e/35e488548e952795829e129995c4174df33bf432b591d1aa42c8d9e4e7ad/coverage-7.15.2-cp314-cp314-win_arm64.whl", hash = "sha256:e38def96ad59853824c97953fdcd2c320a84ba3ce99b417db78af8bb6c3db635", size = 223760, upload-time = "2026-07-15T18:55:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/49/dd2c86cd6374038f6e415fb5bfb86db5218553209c081384a020369dee79/coverage-7.15.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:835ec4e20b45f0a7f63ed78f94065aca00de033403df8377bfe8b9c6abc0a7be", size = 222384, upload-time = "2026-07-15T18:55:45.569Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/173ff17a1c0808e5a438f549f6f145d5ac7528f2791310b63523e3200ac7/coverage-7.15.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7466cc7ab6dc0db871d264bf99e8779f0917ee63d40730af0552f71535a6e072", size = 222647, upload-time = "2026-07-15T18:55:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f8/b8cba872162356fb44ac79c10309d987206a4461e32072fc29228dad7331/coverage-7.15.2-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e370c12133095ff18432de8c044962be85a5a96d90c6fcbce8e17e76236d2328", size = 264013, upload-time = "2026-07-15T18:55:49.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/67/a807a7586d0b8cae485308ddd55756f0806c92f8e0b411bacbf23c48edf3/coverage-7.15.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fe41909c9515c3bfdb5f02c4d1f857dba322d9a9a1178069b91eea77889df63a", size = 266135, upload-time = "2026-07-15T18:55:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/cd78771dc985f7e4ebdcc82b1a96d9a932af9e806f01f2f91a89f4c72e80/coverage-7.15.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6aa28cfb6488e5453b5b762d65f73aa586380f6693a04d58078ce228a29b06c0", size = 268555, upload-time = "2026-07-15T18:55:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3e/10134cf81275188c58568f324fc74aedff32c63ca4d5bbc513a91944a6f0/coverage-7.15.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcc0aae933921d03096f53b0b03eeb702129fd406dee59f08d2efacc68681fa5", size = 269674, upload-time = "2026-07-15T18:55:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/771b77de446cba985dc414bbc5844bd21604da05dbc044286df8318a48a7/coverage-7.15.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7c63387e21ab21f512c69c9756a8c7dadd322c7275edb064064433c9a09c3743", size = 263101, upload-time = "2026-07-15T18:55:58.107Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b5/70a7011da15f4071943361183aefa27847f3e3aec4fd335f1cb3d3a622b1/coverage-7.15.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e55510bc98ae943cece9e667a6c0fe94c6a92913720dea34243657a17993d0c", size = 266007, upload-time = "2026-07-15T18:56:00.468Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/f9547e804ce7ad49646ffeffac26699510efbe6c0f751b66fdc960c4e825/coverage-7.15.2-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:2ff08701be2d1556fc78b326c80a3e8042da09352ecb3819105f8e386c8a3071", size = 263611, upload-time = "2026-07-15T18:56:02.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/59/f576a396659c0efd351f5c1544f67c3560e89c7761cabf7f65e412beeda5/coverage-7.15.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:38c9518b7103826c403a461544e3c2e77151e8676d06eaed85911a97e962584a", size = 267344, upload-time = "2026-07-15T18:56:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5d/c2e4fce3579c0cb635024293f1a32bbe26df101b3e3a69f22243d1352b6c/coverage-7.15.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:dee88b1ed88587abd8c0269a1fc1f4cc77f7750d1dfde2869e2a123af420e67d", size = 262456, upload-time = "2026-07-15T18:56:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/956287d69436b66094bc4b57ac2da71e43bfd2a5524e958900b9f582fcf8/coverage-7.15.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fbeeeecea279727f8ac16c8e1133ddfeee793e985c86ae343d6a5ce744eef8c", size = 264771, upload-time = "2026-07-15T18:56:08.795Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/5a/6f979530c2734c575de77cf58f5f28d51f7123a94b5030fd9156fe5f363c/coverage-7.15.2-cp314-cp314t-win32.whl", hash = "sha256:cb0fddaa6884be6aae36ced9544b5e90f7d5f03845a2853bf47a14953a4e8688", size = 224151, upload-time = "2026-07-15T18:56:10.856Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/27f6b2a74d484742f4017553e710b01e396b23d809df3e95ca0bb9a2824b/coverage-7.15.2-cp314-cp314t-win_amd64.whl", hash = "sha256:77f091ea3a9cc611cd29f433565476bc1936c084ac8eee00ea0e7e70c27e4199", size = 224981, upload-time = "2026-07-15T18:56:12.928Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/48/284863423aa474240f6842bd00d680da22f4e6ea2e466618ef7c9c9e69a9/coverage-7.15.2-cp314-cp314t-win_arm64.whl", hash = "sha256:6fc448c377d6eeb00a47c673494bd9bae29280ca53987e1869e67ebedfe20658", size = 224294, upload-time = "2026-07-15T18:56:15.156Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/82/32e3bd191d498e64f6f911ad55d14006a0861e54869d2d32452326399e65/coverage-7.15.2-py3-none-any.whl", hash = "sha256:eb6bcae8d1a9d305351ecb108232441d11c5cfe9de840a04388ba5d2db8d735c", size = 213375, upload-time = "2026-07-15T18:56:17.305Z" },
 ]
 
 [package.optional-dependencies]
@@ -360,11 +357,11 @@ wheels = [
 
 [[package]]
 name = "docutils"
-version = "0.21.2"
+version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -390,11 +387,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.0.1"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4d/b793283bf4d002e7ffa8ad45c125f1f2306b238c0a641677d6b3a7397f1a/extra_platforms-13.0.1.tar.gz", hash = "sha256:2194e5cd8d58fbbba42d2810f15fea3da072020109998ca8d7ec938abcf59717", size = 80935, upload-time = "2026-06-18T15:58:55.474Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/c5/fae67f4681a664ad855b0cc219b89459f2144e144966b56abc2c63af2921/extra_platforms-13.3.1.tar.gz", hash = "sha256:1efefa780f0b97dce5d352f7873065988f7f23938af70456182b20474849d1c2", size = 86205, upload-time = "2026-07-17T14:02:38.235Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/f8/d9c3fb099faa51808f80255cc94df94f283be8a61e842459e8bb3e12dab0/extra_platforms-13.0.1-py3-none-any.whl", hash = "sha256:fd3b572504557e4b48323dc9704baf2fa939aed37dba5d9963a4aeffd3c9e325", size = 84499, upload-time = "2026-06-18T15:58:54.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/77/aa1591668c391444dd4c30e29936cfaf42177ac9cc6073a681ca510bab02/extra_platforms-13.3.1-py3-none-any.whl", hash = "sha256:ffec89f6f5a983ea2be29970ee7144b2fa53a0fab381ce2b1ed447f4ad63d7a0", size = 89802, upload-time = "2026-07-17T14:02:36.684Z" },
 ]
 
 [package.optional-dependencies]
@@ -404,7 +401,7 @@ pytest = [
 
 [[package]]
 name = "furo"
-version = "2025.9.25"
+version = "2025.12.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "accessible-pygments" },
@@ -413,9 +410,9 @@ dependencies = [
     { name = "sphinx" },
     { name = "sphinx-basic-ng" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/29/ff3b83a1ffce74676043ab3e7540d398e0b1ce7660917a00d7c4958b93da/furo-2025.9.25.tar.gz", hash = "sha256:3eac05582768fdbbc2bdfa1cdbcdd5d33cfc8b4bd2051729ff4e026a1d7e0a98", size = 1662007, upload-time = "2025-09-25T21:37:19.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/69/964b55f389c289e16ba2a5dfe587c3c462aac09e24123f09ddf703889584/furo-2025.9.25-py3-none-any.whl", hash = "sha256:2937f68e823b8e37b410c972c371bc2b1d88026709534927158e0cb3fac95afe", size = 340409, upload-time = "2025-09-25T21:37:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
 ]
 
 [[package]]
@@ -724,7 +721,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -735,47 +732,47 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
 name = "pytest-github-actions-annotate-failures"
-version = "0.3.0"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/d4/c54ee6a871eee4a7468e3a8c0dead28e634c0bc2110c694309dcb7563a66/pytest_github_actions_annotate_failures-0.3.0.tar.gz", hash = "sha256:d4c3177c98046c3900a7f8ddebb22ea54b9f6822201b5d3ab8fcdea51e010db7", size = 11248, upload-time = "2025-01-17T22:39:32.722Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/a0/bdb91581b03c41016c78e16b8ec36c34d8508206fcb30f1951c9cdff2e97/pytest_github_actions_annotate_failures-0.4.2.tar.gz", hash = "sha256:5dd18304512361788bc7b5c5c805db853f03f4950c6be09b088de6bab8e2e6c9", size = 12158, upload-time = "2026-06-19T15:59:17.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/73/7b0b15cb8605ee967b34aa1d949737ab664f94e6b0f1534e8339d9e64ab2/pytest_github_actions_annotate_failures-0.3.0-py3-none-any.whl", hash = "sha256:41ea558ba10c332c0bfc053daeee0c85187507b2034e990f21e4f7e5fef044cf", size = 6030, upload-time = "2025-01-17T22:39:31.701Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/09/c44e658f3a27c588c2017d858c8b0fa962612af9b74326beabbf010c839c/pytest_github_actions_annotate_failures-0.4.2-py3-none-any.whl", hash = "sha256:02911cd3b55f235328a334f8ca6037a89944398b8e8b028c82de97111eff4071", size = 6151, upload-time = "2026-06-19T15:59:16.486Z" },
 ]
 
 [[package]]
 name = "pytest-randomly"
-version = "4.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/1d/258a4bf1109258c00c35043f40433be5c16647387b6e7cd5582d638c116b/pytest_randomly-4.0.1.tar.gz", hash = "sha256:174e57bb12ac2c26f3578188490bd333f0e80620c3f47340158a86eca0593cd8", size = 14130, upload-time = "2025-09-12T15:23:00.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/3e/a4a9227807b56869790aad3e24472a554b585974fe7e551ea350f50897ae/pytest_randomly-4.0.1-py3-none-any.whl", hash = "sha256:e0dfad2fd4f35e07beff1e47c17fbafcf98f9bf4531fd369d9260e2f858bfcb7", size = 8304, upload-time = "2025-09-12T15:22:58.946Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
 ]
 
 [[package]]
@@ -885,18 +882,6 @@ wheels = [
 ]
 
 [[package]]
-name = "roman-numerals-py"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "roman-numerals" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/2c/daca29684cbe9fd4bc711f8246da3c10adca1ccc4d24436b17572eb2590e/roman_numerals_py-4.1.0-py3-none-any.whl", hash = "sha256:553114c1167141c1283a51743759723ecd05604a1b6b507225e91dc1a6df0780", size = 4547, upload-time = "2025-12-17T18:25:40.136Z" },
-]
-
-[[package]]
 name = "snowballstemmer"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -916,7 +901,7 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "8.2.3"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alabaster" },
@@ -928,7 +913,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pygments" },
     { name = "requests" },
-    { name = "roman-numerals-py" },
+    { name = "roman-numerals" },
     { name = "snowballstemmer" },
     { name = "sphinxcontrib-applehelp" },
     { name = "sphinxcontrib-devhelp" },
@@ -937,21 +922,21 @@ dependencies = [
     { name = "sphinxcontrib-qthelp" },
     { name = "sphinxcontrib-serializinghtml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
 ]
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.5.2"
+version = "3.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/4f/4fd5583678bb7dc8afa69e9b309e6a99ee8d79ad3a4728f4e52fd7cb37c7/sphinx_autodoc_typehints-3.5.2.tar.gz", hash = "sha256:5fcd4a3eb7aa89424c1e2e32bedca66edc38367569c9169a80f4b3e934171fdb", size = 37839, upload-time = "2025-10-16T00:50:15.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/ae/8ad5e79a0f7beac5e5810b2a8d0a1c6c63c795ba265a81970070abf15f32/sphinx_autodoc_typehints-3.12.1.tar.gz", hash = "sha256:4bbf6f6b907586d3b2a3ae2b23e0f86be939f19a7449e917d304df57ff9674d1", size = 84421, upload-time = "2026-07-03T13:52:09.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/f2/9657c98a66973b7c35bfd48ba65d1922860de9598fbb535cd96e3f58a908/sphinx_autodoc_typehints-3.5.2-py3-none-any.whl", hash = "sha256:0accd043619f53c86705958e323b419e41667917045ac9215d7be1b493648d8c", size = 21184, upload-time = "2025-10-16T00:50:13.973Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/d5964523f0c98e39ef608a09f3de23032aa32fbe3e98a262e2112c39f985/sphinx_autodoc_typehints-3.12.1-py3-none-any.whl", hash = "sha256:932472c9cc160e6a0dc34eca13d3d6a9823ed6e6dc505d7c12f6963c983cf8f6", size = 42950, upload-time = "2026-07-03T13:52:07.696Z" },
 ]
 
 [[package]]
@@ -968,16 +953,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-click"
-version = "6.1.0"
+version = "6.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "docutils" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/4b/c433ea57136eac0ccb8d76d33355783f1e6e77f1f13dc7d8f15dba2dc024/sphinx_click-6.1.0.tar.gz", hash = "sha256:c702e0751c1a0b6ad649e4f7faebd0dc09a3cc7ca3b50f959698383772f50eef", size = 26855, upload-time = "2025-09-11T11:05:45.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/ed/a9767cd1b8b7fbdf260a89d5c8c86e20e3536b9878579e5ab7965a291e55/sphinx_click-6.2.0.tar.gz", hash = "sha256:fc78b4154a4e5159462e36de55b8643747da6cda86b3b52a8bb62289e603776c", size = 27035, upload-time = "2025-12-04T19:33:05.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/95/a2fa680f02ee9cbe4532169d2e60b102fe415b6cfa25584ac2d112e4c43b/sphinx_click-6.1.0-py3-none-any.whl", hash = "sha256:7dbed856c3d0be75a394da444850d5fc7ecc5694534400aa5ed4f4849a8643f9", size = 8931, upload-time = "2025-09-11T11:05:43.897Z" },
+    { url = "https://files.pythonhosted.org/packages/44/bd/cb244695f67f77b0a36200ce1670fc42a6fe2770847e870daab99cc2b177/sphinx_click-6.2.0-py3-none-any.whl", hash = "sha256:1fb1851cb4f2c286d43cbcd57f55db6ef5a8d208bfc3370f19adde232e5803d7", size = 8939, upload-time = "2025-12-04T19:33:04.037Z" },
 ]
 
 [[package]]
@@ -994,14 +979,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-design"
-version = "0.6.1"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/69/b34e0cb5336f09c6866d53b4a19d76c227cdec1bbc7ac4de63ca7d58c9c7/sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632", size = 2193689, upload-time = "2024-08-02T13:48:44.277Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/43/65c0acbd8cc6f50195a3a1fc195c404988b15c67090e73c7a41a9f57d6bd/sphinx_design-0.6.1-py3-none-any.whl", hash = "sha256:b11f37db1a802a183d61b159d9a202314d4d2fe29c163437001324fe2f19549c", size = 2215338, upload-time = "2024-08-02T13:48:42.106Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl", hash = "sha256:f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282", size = 2220350, upload-time = "2026-01-19T13:12:51.077Z" },
 ]
 
 [[package]]
@@ -1042,15 +1027,16 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-mermaid"
-version = "1.2.3"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "jinja2" },
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/49/c6ddfe709a4ab76ac6e5a00e696f73626b2c189dc1e1965a361ec102e6cc/sphinxcontrib_mermaid-1.2.3.tar.gz", hash = "sha256:358699d0ec924ef679b41873d9edd97d0773446daf9760c75e18dc0adfd91371", size = 18885, upload-time = "2025-11-26T04:18:32.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/9d/bf3a48a657682c7e0445c71d916bca7ab8194454276cc22b16e7f974e502/sphinxcontrib_mermaid-2.1.0.tar.gz", hash = "sha256:13c5f9ac395cb6abf403eca34e228dc9fb3a30c9d960dbf3e40e9a8cef969549", size = 21695, upload-time = "2026-07-18T23:08:11.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl", hash = "sha256:5be782b27026bef97bfb15ccb2f7868b674a1afc0982b54cb149702cfc25aa02", size = 13413, upload-time = "2025-11-26T04:18:31.269Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/bd/d3348d62296e73a91420f0edf671450c9003ecd8704da40b1e3d9b868459/sphinxcontrib_mermaid-2.1.0-py3-none-any.whl", hash = "sha256:417cd144ec4b28852f46ba653f02ce8e538881c812111671a4c30344e87f2112", size = 16190, upload-time = "2026-07-18T23:08:10.098Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-19`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [coverage](https://pypi.org/project/coverage/) | [`7.12.0` → `7.15.2`](https://github.com/coveragepy/coveragepy/compare/7.12.0...7.15.2) | 2026-07-15 (a week ago) |
| [docutils](https://pypi.org/project/docutils/) | `0.21.2` → `0.22.4` | 2025-12-18 (7 months ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.0.1` → `13.3.1`](https://github.com/kdeldycke/extra-platforms/compare/v13.0.1...v13.3.1) | 2026-07-17 (a week ago) |
| [furo](https://pypi.org/project/furo/) | [`2025.9.25` → `2025.12.19`](https://github.com/pradyunsg/furo/compare/2025.9.25...2025.12.19) | 2025-12-19 (7 months ago) |
| [pytest](https://pypi.org/project/pytest/) | [`9.0.3` → `9.1.1`](https://github.com/pytest-dev/pytest/compare/9.0.3...9.1.1) | 2026-06-19 (a month ago) |
| [pytest-cov](https://pypi.org/project/pytest-cov/) | [`7.0.0` → `7.1.0`](https://github.com/pytest-dev/pytest-cov/issues/compare/v7.0.0...v7.1.0) | 2026-03-21 (4 months ago) |
| [pytest-github-actions-annotate-failures](https://pypi.org/project/pytest-github-actions-annotate-failures/) | `0.3.0` → `0.4.2` | 2026-06-19 (a month ago) |
| [pytest-randomly](https://pypi.org/project/pytest-randomly/) | [`4.0.1` → `4.1.0`](https://github.com/pytest-dev/pytest-randomly/compare/v4.0.1...v4.1.0) | 2026-04-20 (3 months ago) |
| [roman-numerals-py](https://pypi.org/project/roman-numerals-py/) | 🗑️ removed: `4.1.0` |  |
| [sphinx](https://pypi.org/project/sphinx/) | [`8.2.3` → `9.1.0`](https://github.com/sphinx-doc/sphinx/compare/v8.2.3...v9.1.0) | 2025-12-31 (7 months ago) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.5.2` → `3.12.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.5.2...3.12.1) | 2026-07-03 (a month ago) |
| [sphinx-click](https://pypi.org/project/sphinx-click/) | `6.1.0` → `6.2.0` | 2025-12-04 (8 months ago) |
| [sphinx-design](https://pypi.org/project/sphinx-design/) | [`0.6.1` → `0.7.0`](https://github.com/executablebooks/sphinx-design/compare/v0.6.1...v0.7.0) | 2026-01-19 (6 months ago) |
| [sphinxcontrib-mermaid](https://pypi.org/project/sphinxcontrib-mermaid/) | [`1.2.3` → `2.1.0`](https://github.com/mgaitan/sphinxcontrib-mermaid/compare/v1.2.3...v2.1.0) | 2026-07-18 (a week ago) |

### Release notes

<details>
<summary><code>coverage</code></summary>

#### [`7.12.1b1`](https://github.com/coveragepy/coveragepy/releases/tag/7.12.1b1)

##### Version 7.12.1b1 — 2025-11-30

- Fix: coverage.py now includes a permanent .pth file in the distribution which is installed with the code. This fixes [issue 2084](https://redirect.github.com/coveragepy/coveragepy/issues/2084): failure to patch for subprocess measurement when site-packages is not writable.

:arrow_right:  PyPI page: [coverage 7.12.1b1](https://pypi.org/project/coverage/7.12.1b1).
:arrow_right:  To install: `python3 -m pip install coverage==7.12.1b1`

#### [`7.13.0`](https://github.com/coveragepy/coveragepy/releases/tag/7.13.0)

##### Version 7.13.0 — 2025-12-08

- Feature: coverage.py now supports `.coveragerc.toml` configuration files. These files use TOML syntax and take priority over `pyproject.toml` but lower priority than `.coveragerc` files. Closes [issue 1643](https://redirect.github.com/coveragepy/coveragepy/issues/1643) thanks to [Olena Yefymenko](https://redirect.github.com/coveragepy/coveragepy/pull/1952).
- Fix: we now include a permanent .pth file which is installed with the code, fixing [issue 2084](https://redirect.github.com/coveragepy/coveragepy/issues/2084). In 7.12.1b1 this was done incorrectly: it didn’t work when using the source wheel (`py3-none-any`). This is now fixed. Thanks, [Henry Schreiner](https://redirect.github.com/coveragepy/coveragepy/pull/2100).
- Deprecated: when coverage.py is installed, it creates three command entry points: `coverage`, `coverage3`, and `coverage-3.10` (if installed for Python 3.10). The second and third of these are not needed and will eventually be removed. They still work for now, but print a message about their deprecation.

:arrow_right:  PyPI page: [coverage 7.13.0](https://pypi.org/project/coverage/7.13.0).
:arrow_right:  To install: `python3 -m pip install coverage==7.13.0`

#### [`7.13.1`](https://github.com/coveragepy/coveragepy/releases/tag/7.13.1)

##### Version 7.13.1 — 2025-12-28

- Added: the JSON report now includes a `"start_line"` key for function and class regions, indicating the first line of the region in the source. Closes [issue 2110](https://redirect.github.com/coveragepy/coveragepy/issues/2110).
- Added: The `debug data` command now takes file names as arguments on the command line, so you can inspect specific data files without needing to set the `COVERAGE_FILE` environment variable.
- Fix: the JSON report used to report module docstrings as executed lines, which no other report did, as described in [issue 2105](https://redirect.github.com/coveragepy/coveragepy/issues/2105). This is now fixed, thanks to Jianrong Zhao.
- Fix: coverage.py uses a more disciplined approach to detecting where third-party code is installed, and avoids measuring it. This shouldn’t change any behavior. If you find that it does, please get in touch.
- Performance: data files that will be combined now record their hash as part of the file name. This lets us skip duplicate data more quickly, speeding the combining step.
- Docs: added a section explaining more about what is considered a missing branch and how it is reported: [Examples of missing branches](https://coverage.readthedocs.io/en/latest/branch.html#branch-explain), as requested in [issue 1597](https://redirect.github.com/coveragepy/coveragepy/issues/1597). Thanks to [Ayisha Mohammed](https://redirect.github.com/coveragepy/coveragepy/pull/2092).
- Tests: the test suite misunderstood what core was being tested if `COVERAGE_CORE` wasn’t set on 3.14+. This is now fixed, closing [issue 2109](https://redirect.github.com/coveragepy/coveragepy/issues/2109).

:arrow_right:  PyPI page: [coverage 7.13.1](https://pypi.org/project/coverage/7.13.1).
:arrow_right:  To install: `python3 -m pip install coverage==7.13.1`

#### [`7.13.2`](https://github.com/coveragepy/coveragepy/releases/tag/7.13.2)

##### Version 7.13.2 — 2026-01-25

- Fix: when Python is installed via symlinks, for example with Homebrew, the standard library files could be incorrectly included in coverage reports. This is now fixed, closing [issue 2115](https://redirect.github.com/coveragepy/coveragepy/issues/2115).
- Fix: if a data file is created with no read permissions, the combine step would fail completely. Now a warning is issued and the file is skipped. Closes [issue 2117](https://redirect.github.com/coveragepy/coveragepy/issues/2117).

:arrow_right:  PyPI page: [coverage 7.13.2](https://pypi.org/project/coverage/7.13.2).
:arrow_right:  To install: `python3 -m pip install coverage==7.13.2`

#### [`7.13.3`](https://github.com/coveragepy/coveragepy/releases/tag/7.13.3)

##### Version 7.13.3 — 2026-02-03

- Fix: in some situations, third-party code was measured when it shouldn’t have been, slowing down test execution. This happened with layered virtual environments such as uv sometimes makes. The problem is fixed, closing [issue 2082](https://redirect.github.com/coveragepy/coveragepy/issues/2082). Now any directory on sys.path that is inside a virtualenv is considered third-party code.

:arrow_right:  PyPI page: [coverage 7.13.3](https://pypi.org/project/coverage/7.13.3).
:arrow_right:  To install: `python3 -m pip install coverage==7.13.3`

#### [`7.13.4`](https://github.com/coveragepy/coveragepy/releases/tag/7.13.4)

##### Version 7.13.4 — 2026-02-09

- Fix: the third-party code fix in 7.13.3 required examining the parent directories where coverage was run. In the unusual situation that one of the parent directories is unreadable, a PermissionError would occur, as described in [issue 2129](https://redirect.github.com/coveragepy/coveragepy/issues/2129). This is now fixed.
- Fix: in test suites that change sys.path, coverage.py could fail with “RuntimeError: Set changed size during iteration” as described and fixed in [pull 2130](https://redirect.github.com/coveragepy/coveragepy/pull/2130). Thanks, Noah Fatsi.
- We now publish ppc64le wheels, thanks to [Pankhudi Jain](https://redirect.github.com/coveragepy/coveragepy/pull/2121).

:arrow_right:  PyPI page: [coverage 7.13.4](https://pypi.org/project/coverage/7.13.4).
:arrow_right:  To install: `python3 -m pip install coverage==7.13.4`

#### [`7.13.5`](https://github.com/coveragepy/coveragepy/releases/tag/7.13.5)

##### Version 7.13.5 — 2026-03-17

- Fix: [issue 2138](https://redirect.github.com/coveragepy/coveragepy/issues/2138) describes a memory leak that happened when repeatedly using the Coverage API with in-memory data. This is now fixed.
- Fix: the markdown-formatted coverage report didn’t fully escape special characters in file paths ([issue 2141](https://redirect.github.com/coveragepy/coveragepy/issues/2141)). This would be very unlikely to cause a problem, but now it’s done properly, thanks to [Ellie Ayla](https://redirect.github.com/coveragepy/coveragepy/pull/2142).
- Fix: the C extension wouldn’t build on VS2019, but now it does ([issue 2145](https://redirect.github.com/coveragepy/coveragepy/issues/2145)).

:arrow_right:  PyPI page: [coverage 7.13.5](https://pypi.org/project/coverage/7.13.5).
:arrow_right:  To install: `python3 -m pip install coverage==7.13.5`

#### [`7.14.0`](https://github.com/coveragepy/coveragepy/releases/tag/7.14.0)

##### Version 7.14.0 — 2026-05-10

- Feature: now when running one of the reporting commands, if there are parallel data files that need combining, they will be implicitly combined before creating the report. There is no option to avoid the combination; let us know if you have a use case that requires it. Thanks, [Tim Hatch](https://redirect.github.com/coveragepy/coveragepy/pull/2162). Closes [issue 1781](https://redirect.github.com/coveragepy/coveragepy/issues/1781).
- Fix: the output from `combine` was too verbose, listing each file considered. Now it shows a single line with the counts of files combined, files skipped, and files with errors. The `-q` flag suppresses this line. The old detailed lines are available with the new `--debug=combine` option.
- Fix: running a Python file through a symlink now sets the sys.path correctly, matching regular Python behavior. Fixes [issue 2157](https://redirect.github.com/coveragepy/coveragepy/issues/2157).
- Fix: `Collector.flush_data` could fail with “RuntimeError: Set changed size during iteration” when a tracer in another thread added a line to the per-file set that `add_lines` (or `add_arcs`) was iterating. The values passed to `CoverageData` are now snapshotted via `dict.copy()` and `set.copy()`, which are atomic under the GIL. Thanks, [Alex Vandiver](https://redirect.github.com/coveragepy/coveragepy/pull/2165).
- Fix: the soft keyword `lazy` is now bolded in HTML reports.
- We are no longer testing eventlet support. Eventlet started issuing stern deprecation warnings that break our tests. Our support code is still there.

:arrow_right:  PyPI page: [coverage 7.14.0](https://pypi.org/project/coverage/7.14.0).
:arrow_right:  To install: `python3 -m pip install coverage==7.14.0`

#### [`7.14.1`](https://github.com/coveragepy/coveragepy/releases/tag/7.14.1)

##### Version 7.14.1 — 2026-05-26

- Fix: the HTML report used typographic niceties to make file paths more readable by adding a small amount of space around slashes. Those spaces interfered with searching the page for file paths of interest. Now the report uses CSS to accomplish the same visual tweak so that searches with slashes work correctly. Closes [issue 2170](https://redirect.github.com/coveragepy/coveragepy/issues/2170).
- [Add a 3.16 PyPI classifier](https://mastodon.social/@hugovk/116588523571204490) since we test on the 3.16 main branch.

:arrow_right:  PyPI page: [coverage 7.14.1](https://pypi.org/project/coverage/7.14.1).
:arrow_right:  To install: `python3 -m pip install coverage==7.14.1`

#### [`7.14.2`](https://github.com/coveragepy/coveragepy/releases/tag/7.14.2)

##### Version 7.14.2 — 2026-06-20

- Fix: some messages were being written to stdout, making `coverage json -o -` useless for capturing JSON output. Now messages are written to stderr, fixing [issue 2197](https://redirect.github.com/coveragepy/coveragepy/issues/2197).
- Fix: `CoverageData` kept one SQLite connection per thread that recorded coverage, but never closed them when those threads terminated. On long runs with many short-lived threads this leaked one file descriptor per dead thread, eventually failing with `OSError: [Errno 24] Too many open files`. Connections belonging to terminated threads are now closed and dropped. Fixes [issue 2192](https://redirect.github.com/coveragepy/coveragepy/issues/2192). Thanks, [Matthew Lloyd](https://redirect.github.com/coveragepy/coveragepy/pull/2193).
- Fix: when using sys.monitoring, we were assuming we could use the `COVERAGE_ID` tool id. But other tools might also assume they could use that id. Pre-allocated ids don’t really make sense, so now we search for a usable one instead. Fixes [issue 2187](https://redirect.github.com/coveragepy/coveragepy/issues/2187).
- Following [the advice of cibuildwheel](https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel), we no longer distribute wheels for Python 3.13 free-threaded.

:arrow_right:  PyPI page: [coverage 7.14.2](https://pypi.org/project/coverage/7.14.2).
:arrow_right:  To install: `python3 -m pip install coverage==7.14.2`

#### [`7.14.3`](https://github.com/coveragepy/coveragepy/releases/tag/7.14.3)

##### Version 7.14.3 — 2026-06-22

- Fix: the default `...` exclusion rule now also matches function bodies whose closing return-type bracket is on its own line (for example, after a long `-> dict[ ... ]` annotation that a formatter has split over multiple lines). Closes [issue 2185](https://redirect.github.com/coveragepy/coveragepy/issues/2185), thanks [Mengjia Shang](https://redirect.github.com/coveragepy/coveragepy/pull/2196).
- Fix: On 3.13t, we incorrectly issued `Couldn't import C tracer` errors. We can’t import the C tracer because in 7.14.2 we stopped shipping compiled wheels for 3.13t. Thanks, [Hugo van Kemenade](https://redirect.github.com/coveragepy/coveragepy/pull/2203).

:arrow_right:  PyPI page: [coverage 7.14.3](https://pypi.org/project/coverage/7.14.3).
:arrow_right:  To install: `python3 -m pip install coverage==7.14.3`

#### [`7.15.0`](https://github.com/coveragepy/coveragepy/releases/tag/7.15.0)

##### Version 7.15.0 — 2026-07-02

- Since 7.14.0, reporting commands implicitly combine parallel data files. Now those commands have a new option `--keep-combined` to retain the data files after combining them instead of the default, which is to delete them. Finishes [issue 2198](https://redirect.github.com/coveragepy/coveragepy/issues/2198).
- Fix: the LCOV report would incorrectly count excluded functions as uncovered, as described in [issue 2205](https://redirect.github.com/coveragepy/coveragepy/issues/2205). This is now fixed thanks to [Martin Kuntz Jacobsen](https://redirect.github.com/coveragepy/coveragepy/pull/2206).
- When running your program, coverage now correctly sets `yourmodule.__spec__.loader` as [strongly recommended](), avoiding the deprecation warning described in [issue 2208](https://redirect.github.com/coveragepy/coveragepy/issues/2208). Thanks, [A5rocks](https://redirect.github.com/coveragepy/coveragepy/pull/2209).
- Fix: with Python 3.10, running with the `-I` (isolated mode) option didn’t correctly omit the current directory from the module search path, as described in [issue 2103](https://redirect.github.com/coveragepy/coveragepy/issues/2103). That is now fixed thanks to [Ilia Sorokin](https://redirect.github.com/coveragepy/coveragepy/pull/2211).

:arrow_right:  PyPI page: [coverage 7.15.0](https://pypi.org/project/coverage/7.15.0).
:arrow_right:  To install: `python3 -m pip install coverage==7.15.0`

#### [`7.15.1`](https://github.com/coveragepy/coveragepy/releases/tag/7.15.1)

##### Version 7.15.1 — 2026-07-12

- Fix: in the HTML report with `show_contexts` enabled, a context label containing `</script>` (for example a parametrized pytest node id) could close the inline `<script>` element in a file page early, injecting markup. Context labels are now fully escaped. Thanks, [Rajath Mohare](https://redirect.github.com/coveragepy/coveragepy/pull/2224).
- A number of performance improvements thanks to Paul Kehrer, in pull requests [2213](https://redirect.github.com/coveragepy/coveragepy/pull/2213), [2214](https://redirect.github.com/coveragepy/coveragepy/pull/2214), [2215](https://redirect.github.com/coveragepy/coveragepy/pull/2215), [2216](https://redirect.github.com/coveragepy/coveragepy/pull/2216), [2218](https://redirect.github.com/coveragepy/coveragepy/pull/2218), [2220](https://redirect.github.com/coveragepy/coveragepy/pull/2220), and [2221](https://redirect.github.com/coveragepy/coveragepy/pull/2221).

:arrow_right:  PyPI page: [coverage 7.15.1](https://pypi.org/project/coverage/7.15.1).
:arrow_right:  To install: `python3 -m pip install coverage==7.15.1`

#### [`7.15.2`](https://github.com/coveragepy/coveragepy/releases/tag/7.15.2)

##### Version 7.15.2 — 2026-07-15

- Fix: one of the performance improvements in 7.15.1 (pull 2215) dramatically increased memory use during reporting for large projects. Now we use a different approach that is both faster and slimmer than 7.15.0. Fixes [issue 2229](https://redirect.github.com/coveragepy/coveragepy/issues/2229).

:arrow_right:  PyPI page: [coverage 7.15.2](https://pypi.org/project/coverage/7.15.2).
:arrow_right:  To install: `python3 -m pip install coverage==7.15.2`

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.1.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.1.0)

> [!NOTE]
> `13.1.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.1.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.1.0).

- Add ChromeOS platform detection: `CHROMEOS` / `is_chromeos()`, covering ChromeOS itself, ChromiumOS and derivatives like FydeOS, and the Crostini Linux container, where `current_platform()` prefers the container's own distribution, as with WSL.
- Add Clear Linux OS platform detection: `CLEARLINUX` / `is_clearlinux()` (via `ID=clear-linux-os` in `os-release`).
- Add SliTaz GNU/Linux platform detection: `SLITAZ` / `is_slitaz()` (via `/etc/slitaz-release`, as SliTaz ships no `os-release` file).
- Add Source Mage GNU/Linux platform detection: `SOURCEMAGE` / `is_sourcemage()` (via `ID=sourcemage` in `os-release`).
- Upload coverage to Codecov from one runner per OS, on the oldest and newest Python, instead of every test matrix cell.
- Drop the Codecov Test Analytics upload and the `junit.xml` report generation.
- Assert CLI behavior in CI with a declarative `click-extra` test suite (`tests/cli-test-suite.toml`), replacing the hand-rolled smoke invocations.
- Add the `macos-15-intel` runner to the test matrix.

**Full changelog**: [`v13.0.1...v13.1.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.0.1...v13.1.0)

#### [`v13.2.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.2.0)

> [!NOTE]
> `13.2.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.2.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.2.0).

- Add PikaOS platform detection: `PIKAOS` / `is_pikaos()` (via `ID=pika` in `os-release`). Closes [#​610](https://redirect.github.com/kdeldycke/extra-platforms/issues/610)
- Document installation from AUR, GNU Guix, openSUSE Tumbleweed and pkgsrc.

**Full changelog**: [`v13.1.0...v13.2.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.1.0...v13.2.0)

#### [`v13.3.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

> [!NOTE]
> `13.3.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0).

- Deprecate the `TUMBLEWEED` platform: openSUSE Tumbleweed is now detected as `OPENSUSE`. `TUMBLEWEED`, `is_tumbleweed()` and the `skip_tumbleweed`/`unless_tumbleweed` decorators still resolve to their `OPENSUSE` counterparts with a `DeprecationWarning`, and will be removed in `14.0.0`.
- Detect all openSUSE release channels (Tumbleweed, Leap, Slowroll, MicroOS, ...) as `OPENSUSE`. Closes [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- `Platform.info()` now reports the raw `os-release` ID of distribution sub-variants in its `distro_id` field (like `ol` or `opensuse-slowroll`) instead of aliasing it to the canonical platform ID.
- Rename `NON_OVERLAPPING_GROUPS` to `CANONICAL_GROUPS` and `EXTRA_GROUPS` to `NON_CANONICAL_GROUPS`, matching the `Group.canonical` vocabulary. The old names still resolve with a `DeprecationWarning`, and will be removed in `14.0.0`.
- `Trait.info()` is now implemented by the base class with identity metadata: custom `Trait` subclasses are no longer forced to override it.
- Rename the `ALL_CI` group to "All CI systems" and `ALL_AGENTS` to "All AI coding agents", aligning with the other "all" group names.
- `current_traits()` now returns an immutable `frozenset`: mutating the previously returned `set` corrupted its cache.
- `linux_info()` now returns `None` for missing fields instead of empty strings, like `macos_info()` and `windows_info()`.
- Fix pytest decorator skip reasons mangling acronyms and brand names ("Skip cI systems" is now "Skip All CI systems").
- Fix grammar and labels of the `current_*()` multiple-match errors ("Multiple CI matches:" is now "Multiple CI systems match:").
- Fix the `cff-version` schema field in `citation.cff` being overwritten with the package version on every version bump.

... [Full release notes](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.0)

#### [`v13.3.1`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1)

> [!NOTE]
> `13.3.1` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.3.1/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.3.1).

- Fix `test_current_funcs` failing under nested shells: extra shells backed by real ancestor processes (like a fish session running an OBS chroot build) are now accounted for. Addresses [#​619](https://redirect.github.com/kdeldycke/extra-platforms/issues/619)
- Document detection semantics on every trait page: which traits can match simultaneously (shells, platforms, terminals), which are exclusive (architectures, CI systems, agents), and how each `current_*()` function arbitrates or reports absences.
- Skip the whole test workflow on version-bump pushes and pull requests.
- Skip the package install checks on pull requests: they exercise the released package, not the change under review.
- Run the test suite in parallel outside CI too, by moving `--numprocesses=auto` and `--dist=loadgroup` to pytest `addopts`.

**Full changelog**: [`v13.3.0...v13.3.1`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.3.0...v13.3.1)

</details>

<details>
<summary><code>furo</code></summary>

#### [`2025.12.19`](https://github.com/pradyunsg/furo/releases/tag/2025.12.19)

- Bump the supported Sphinx version range

**Full Changelog**: https://redirect.github.com/pradyunsg/furo/compare/2025.09.25...2025.12.19

</details>

<details>
<summary><code>pytest</code></summary>

#### [`9.1.0`](https://github.com/pytest-dev/pytest/releases/tag/9.1.0)

##### pytest 9.1.0 (2026-06-13)

###### Removals and backward incompatible breaking changes

- [\#​14533](https://redirect.github.com/pytest-dev/pytest/issues/14533): When using `--doctest-modules`, autouse fixtures with `module`, `package` or `session` scope that are defined inline in Python test modules (not plugins or conftests) will now possibly execute twice.

  If this is undesirable, move the fixture definition to a `conftest.py` file if possible.

  Technical explanation for those interested:
  When using <span class="title-ref">--doctest-modules</span>, pytest possibly collects Python modules twice, once as `pytest.Module` and once as a `DoctestModule` (depending on the configuration).
  Due to improvements in pytest's fixture implementation, if e.g. the `DoctestModule` collects a fixture, it is now visible to it only, and not to the `Module`.
  This means that both need to register the fixtures independently.

###### Deprecations (removal in next major release)

- [\#​10819](https://redirect.github.com/pytest-dev/pytest/issues/10819): Added a deprecation warning for class-scoped fixtures defined as instance methods (without `@classmethod`). Such fixtures set attributes on a different instance than the test methods use, leading to unexpected behavior. Use `@classmethod` decorator instead -- by `yastcher`.

  See `10819` and `14011`.

- [\#​12882](https://redirect.github.com/pytest-dev/pytest/issues/12882): Calling `request.getfixturevalue() <pytest.FixtureRequest.getfixturevalue>` during teardown to request a fixture that was not already requested is now deprecated and will become an error in pytest 10.

  See `dynamic-fixture-request-during-teardown` for details.

... [Full release notes](https://github.com/pytest-dev/pytest/releases/tag/9.1.0)

#### [`9.1.1`](https://github.com/pytest-dev/pytest/releases/tag/9.1.1)

##### pytest 9.1.1 (2026-06-19)

###### Bug fixes

- [\#​14220](https://redirect.github.com/pytest-dev/pytest/issues/14220): Fixed a logic bug in `pytest.RaisesGroup` which would might cause it to display incorrect "It matches <span class="title-ref">FooError()</span> which was paired with <span class="title-ref">BarError</span>" messages.
- [\#​14591](https://redirect.github.com/pytest-dev/pytest/issues/14591): Fixed a regression in pytest 9.1.0 which caused overriding a parametrized fixture with an indirect <span class="title-ref">@​pytest.mark.parametrize</span> to fail with "duplicate parametrization of '\<fixture name\>'".
- [\#​14606](https://redirect.github.com/pytest-dev/pytest/issues/14606): Fixed `list-item` typing errors from mypy in `@pytest.mark.parametrize <pytest.mark.parametrize ref>` `argvalues` parameter.
- [\#​14608](https://redirect.github.com/pytest-dev/pytest/issues/14608): Fixed a regression in pytest 9.1.0 where `conftest.py` files located in `<invocation dir>/test*` were no longer loaded as initial conftests when invoked without arguments.
  This could cause certain hooks (like `pytest_addoption`) in these files to not fire.

</details>

<details>
<summary><code>pytest-cov</code></summary>

[Changelog](https://pytest-cov.readthedocs.io/en/latest/changelog.html)

</details>

<details>
<summary><code>pytest-randomly</code></summary>

[Changelog](https://redirect.github.com/pytest-dev/pytest-randomly/blob/main/CHANGELOG.rst)

</details>

<details>
<summary><code>sphinx</code></summary>

#### [`v9.0.0rc1`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc1)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0rc2`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc2)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0rc3`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc3)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0rc4`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0rc4)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

#### [`v9.0.0`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html


Dependencies
------------

* #​13786: Support [Docutils 0.22](https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-22-2026-07-29). Patch by Adam Turner.

Incompatible changes
--------------------

* #​13639: `SphinxComponentRegistry.create_source_parser` no longer
  has an *app* parameter, instead taking *config* and *env*.
  Patch by Adam Turner.
* #​13679: Non-decodable characters in source files now raise an error.
  Such bytes have been replaced with '?' along with logging a warning
  since Sphinx 2.0.
  Patch by Adam Turner.
* #​13751, #​14089: `sphinx.ext.autodoc` has been substantially rewritten,
  and there may be some incompatible changes in edge cases, especially when
  extensions interact with autodoc internals.
  The `autodoc_use_legacy_class_based` option has been added to
  use the legacy (pre-9.0) implementation of autodoc.
  Patches by Adam Turner.
* #​13355: Don't include escaped title content in the search index.
  Patch by Will Lachance.

Deprecated
----------

* 13627: Deprecate remaining public `app` attributes,
  including ``builder.app``, ``env.app``, ``events.app``,
  and ``SphinxTransform.app``.
  Patch by Adam Turner.
* #​13637: Deprecate the `set_application` method
  of `Parser` objects.
  Patch by Adam Turner.
* #​13644: Deprecate the `Parser.config` and `env` attributes.
  Patch by Adam Turner.
* #​13665: Deprecate support for non-UTF 8 source encodings,
  scheduled for removal in Sphinx 10.
  Patch by Adam Turner.
* #​13682: Deprecate `sphinx.io`.
  Sphinx no longer uses the `sphinx.io` classes,
  having replaced them with standard Python I/O.
  The entire `sphinx.io` module will be removed in Sphinx 10.
  Patch by Adam Turner.
* #​13631: `sphinx.environment.adapters.toctree.global_toctree_for_doc`
  and `sphinx.environment.BuildEnvironment.get_and_resolve_doctree`

... [Full release notes](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.0)

#### [`v9.0.1`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.1)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​13942: autodoc: Restore the mapping interface for options objects.
  Patch by Adam Turner.
* #​13942: autodoc: Deprecate the mapping interface for options objects.
  Patch by Adam Turner.
* #​13387: Update translations.

#### [`v9.0.2`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.2)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​14142: autodoc: Restore `sphinx.ext.autodoc.mock`.
  Patch by Adam Turner.

#### [`v9.0.3`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.3)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​14142: autodoc: Restore some missing exports in `sphinx.ext.autodoc`.
  Patch by Adam Turner.

#### [`v9.0.4`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.0.4)

Changelog: https://www.sphinx-doc.org/en/master/changes/9.0.html

Bugs fixed
----------

* #​14143: Fix spurious build warnings when translators reorder references
  in strings, or use translated display text in references.
  Patch by Matt Wang.

#### [`v9.1.0rc1`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0rc1)

Changelog: https://www.sphinx-doc.org/en/master/changes.html

#### [`v9.1.0rc2`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0rc2)

Changelog: https://www.sphinx-doc.org/en/master/changes.html

#### [`v9.1.0`](https://github.com/sphinx-doc/sphinx/releases/tag/v9.1.0)

Changelog: https://www.sphinx-doc.org/en/master/changes.html

Dependencies
------------

* #​14153: Drop Python 3.11 support.
* #​12555: Drop Docutils 0.20 support.
  Patch by Adam Turner

Features added
--------------

* Add `add_static_dir()` for copying static
  assets from extensions to the build output.
  Patch by Jared Dillard

Bugs fixed
----------

* #​14189: autodoc: Fix duplicate ``:no-index-entry:`` for modules.
  Patch by Adam Turner
* #​13713: Fix compatibility with MyST-Parser.
  Patch by Adam Turner
* Fix tests for Python 3.15.
  Patch by Adam Turner
* #​14089: autodoc: Fix default option parsing.
  Patch by Adam Turner
* Remove incorrect static typing assertions.
  Patch by Adam Turner
* #​14050: LaTeXTranslator fails to build documents using the "acronym"
  standard role.
  Patch by Günter Milde
* LaTeX: Fix rendering for grid filled merged vertical cell.
  Patch by Tim Nordell
* #​14228: LaTeX: Fix overrun footer for cases of merged vertical table cells.
  Patch by Tim Nordell
* #​14207: Fix creating ``HTMLThemeFactory`` objects in third-party extensions.
  Patch by Adam Turner
* #​3099: LaTeX: PDF build crashes if a code-block contains more than
  circa 1350 codelines (about 27 a4-sized pages at default pointsize).
  Patch by Jean-François B.
* #​14064: LaTeX: TABs ending up in sphinxVerbatim fail to obey tab stops.
  Patch by Jean-François B.
* #​14089: autodoc: Improve support for non-weakreferencable objects.
  Patch by Adam Turner
* LaTeX: Fix accidental removal at ``3.5.0`` (#​8854) of the documentation of
  ``literalblockcappos`` key of  sphinxsetup.
  Patch by Jean-François B.

</details>

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.6.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

##### What's Changed
* Use Sphinx 9 class interface by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/589


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.5.2...3.6.0

#### [`3.6.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.1)

<!-- Release notes generated using configuration in .github/release.yml at main -->

##### What's Changed
* Include metadata in type hints by @​AllanChain in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/594

##### New Contributors
* @​AllanChain made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/594

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.0...3.6.1

#### [`3.6.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.2)

<!-- Release notes generated using configuration in .github/release.yml at main -->

##### What's Changed
* Fix compatibility with 9.1.0 by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/595


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.1...3.6.2

#### [`3.6.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.6.3)

<!-- Release notes generated using configuration in .github/release.yml at main -->

##### What's Changed
* 🔧 build(tox): migrate from tox.ini to tox.toml by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/609
* Fix extra () after NewType in rendered output by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/608
* Fix ValueError on wrapper loops in inspect.unwrap by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/607
* Fix IndexError with always_document_param_types and braces-after defaults by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/605
* Fix warning for __new__ of NamedTuple subclasses by @​Fridayai700 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/606

##### New Contributors
* @​Fridayai700 made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/608

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.2...3.6.3

#### [`3.7.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.7.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

##### What's Changed
* Migrate type checking from mypy to ty by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/611
* Move from extras to dependency-groups by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/612
* 🐛 fix(types): resolve PEP 695 type params in annotations by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/614
* fix: separate injected :rtype: from preceding paragraph by @​lweyrich1 in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/615
* 🐛 fix(rtype): skip Return type for generators with Yields by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/616
* 🐛 fix(guard): silence ImportError for third-party guards by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/617
* 🐛 fix(sig): prevent KeyError in method lookup by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/620
* 🐛 fix(annotations): show NewType as alias name with supertype by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/622
* 🐛 fix(annotations): link enum variants in Literal types by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/623
* 🐛 fix(parser): prevent directive side-effects in snippet parsing by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/624

##### New Contributors
* @​lweyrich1 made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/615

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.6.3...3.7.0

#### [`3.8.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.8.0)

<!-- Release notes generated using configuration in .github/release.yml at main -->

##### What's Changed
* ✨ feat(signatures): enable overload signature display by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/625
* ✨ feat(annotations): preserve documented type aliases by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/626
* ✨ feat(annotations): use annotationlib on 3.14+ for forward refs by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/627
* ♻️ refactor(core): extract format-specific submodules by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/628
* ✨ feat(warnings): add source location context by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/629
* ✨ feat(stubs): resolve type hints from .pyi stub files (#​161) by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/630
* ✨ feat(annotations): support Annotated with Doc() for param descriptions by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/631
* 🧪 test(output): normalize Sphinx text for stable comparisons by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/632
* ✨ feat(attrs): backfill type annotations for attrs classes by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/633
* 📝 docs(readme): rewrite with Diataxis framework by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/634


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.7.0...3.8.0

#### [`3.9.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.0)

<!-- Release notes generated using configuration in .github/release.yaml at 3.9.0 -->

##### What's Changed
* Add permissions to workflows by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/636
* ♻️ refactor(tests): consolidate test infrastructure and reach 100% coverage by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/635
* Move SECURITY.md to .github/SECURITY.md by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/639
* Switch FUNDING.yml to github: gaborbernat by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/640
* Standardize .github files to .yaml suffix by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/641
* ✨ feat(annotations): auto-remap internal type paths via intersphinx by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/644
* ✨ feat(overloads): add opt-out control for overload rendering by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/645
* 🐛 fix(resolver): resolve forward refs in nested attrs classes by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/646


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.8.0...3.9.0

#### [`3.9.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(intersphinx): access inventory dict directly by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/647


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.0...3.9.1

#### [`3.9.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.2)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(intersphinx): handle objects without __qualname__ by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/648


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.1...3.9.2

#### [`3.9.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.3)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(intersphinx): exclude builtin type aliases from mapping by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/650


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.2...3.9.3

#### [`3.9.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.4)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(stubs): strip all suffixes for extension modules by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/652


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.3...3.9.4

#### [`3.9.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.5)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(stubs): resolve stub imports for type hint evaluation by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/654


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.4...3.9.5

#### [`3.9.6`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.6)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(stubs): resolve stub type hints for C/Rust extensions by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/655


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.5...3.9.6

#### [`3.9.7`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.7)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(resolver): resolve NamedTuple hints from class by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/657


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.6...3.9.7

#### [`3.9.8`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.8)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(docstring): preserve blank line after field list by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/659


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.7...3.9.8

#### [`3.9.9`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.9)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(stubs): resolve relative imports in .pyi stubs by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/663


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.8...3.9.9

#### [`3.9.10`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.10)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(stubs): use __new__ param annotations not class vars by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/667
* 🐛 fix(stubs): prevent forward ref warnings from stub annotation pollution by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/668


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.9...3.9.10

#### [`3.9.11`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.9.11)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(stubs): resolve imports inside if-blocks in .pyi stubs by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/670
* 🐛 fix(stubs): evaluate stub-only definitions for annotation resolution by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/671


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.10...3.9.11

#### [`3.10.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🔒 ci(workflows): add zizmor security auditing by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/672
* ✨ feat(resolver): auto-inject :vartype: for annotated instance vars by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/678
* 🐛 fix(intersphinx): skip union aliases in type mapping by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/679


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.9.11...3.10.0

#### [`3.10.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(resolver): surface hints for @​no_type_check targets by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/681


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.0...3.10.1

#### [`3.10.2`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.2)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(ivar): tolerate malformed :ivar field entries by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/684


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.1...3.10.2

#### [`3.10.3`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.3)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* Show version in error tracebacks by @​kdeldycke in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/687
* Support PEP 695 `type` statement and python 3.12+ `TypeAliasType` by @​lochhh in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/691
* Fix typehints_formatter cache warning by @​RazerM in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/696
* 🐛 fix(stubs): resolve type hints for PyO3 native submodules by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/702

##### New Contributors
* @​kdeldycke made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/687
* @​lochhh made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/691
* @​RazerM made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/696

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.2...3.10.3

#### [`3.10.4`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.4)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(annotations): avoid NameError for TYPE_CHECKING-only annotations on 3.14 by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/704


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.3...3.10.4

#### [`3.10.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.5)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* process_signature: don't skip the first arg on bound instance methods by @​ilia-kats in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/705
* 🐛 fix(annotations): use class role for Ellipsis/NotImplementedType on 3.13+ by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/707

##### New Contributors
* @​ilia-kats made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/705

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.4...3.10.5

#### [`3.10.6`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.6)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(docstring): keep types on params with a trailing underscore by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/714
* ♻️ refactor(tests): fold per-issue test files into topical ones by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/715
* 🐛 fix(resolver): survive PEP 649 lazy annotation evaluation errors by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/713


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.5...3.10.6

#### [`3.11.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.11.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* ✨ feat(resolver): type C data descriptors from stub files by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/716


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.6...3.11.0

#### [`3.11.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.11.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(annotations): use py:class for types on 3.13+ by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/732
* 🐛 fix(overloads): keep summary above overloads by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/731


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.12.1...3.11.1

#### [`3.12.0`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.12.0)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(annotations): render recursive type aliases by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/721


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.11.0...3.12.0

#### [`3.12.1`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.12.1)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

##### What's Changed
* 🐛 fix(annotations): resolve cross-module recursive alias by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/724


**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.12.0...3.12.1

</details>

<details>
<summary><code>sphinx-design</code></summary>

#### [`v0.7.0`](https://github.com/executablebooks/sphinx-design/releases/tag/v0.7.0)

##### What's Changed
* 🧪 add regression test for available material icons by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/224
* ⬆️ Update Material Design Icons to v4.0.0-116-ge9da21 by @​2bndy5 in https://redirect.github.com/executablebooks/sphinx-design/pull/223
* 📚 Document `muted`, `white`, and `black` semantic colors by @​user27182 in https://redirect.github.com/executablebooks/sphinx-design/pull/216
* ⬆️ Drop Python 3.9 & 3.10, support Python 3.14; Drop sphinx v6 by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/250
* 🔧 Add `AGENTS.md` by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/251
* 🔧 Remove unintended file by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/252
* 🔧 Add copilot-setup-steps.yml workflow for GitHub Copilot coding agent by @​Copilot in https://redirect.github.com/executablebooks/sphinx-design/pull/253
* 🔧 Add commit/pr info to AGENTS.md by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/254
* ⬆️ Add Sphinx 9 support by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/255
* 🚀 Release v0.7.0 by @​chrisjsewell in https://redirect.github.com/executablebooks/sphinx-design/pull/256

##### New Contributors
* @​user27182 made their first contribution in https://redirect.github.com/executablebooks/sphinx-design/pull/216
* @​Copilot made their first contribution in https://redirect.github.com/executablebooks/sphinx-design/pull/253

**Full Changelog**: https://redirect.github.com/executablebooks/sphinx-design/compare/v0.6.1...v0.7.0

</details>

<details>
<summary><code>sphinxcontrib-mermaid</code></summary>

[Changelog](https://redirect.github.com/mgaitan/sphinxcontrib-mermaid/blob/master/CHANGELOG.md)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [bracex](https://pypi.org/project/bracex/) | `3.0` | `3.0.1` | 2026-07-20 (6 days ago) | 2026-07-27 (in a day) |
| [certifi](https://pypi.org/project/certifi/) | `2026.6.17` | `2026.7.22` | 2026-07-22 (4 days ago) | 2026-07-29 (in 3 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9` | `2.9.1` | 2026-07-21 (5 days ago) | 2026-07-28 (in 2 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.12.1` | `3.13.0` | 2026-07-21 (5 days ago) | 2026-07-28 (in 2 days) |
| [types-boltons](https://pypi.org/project/types-boltons/) | `25.0.0.20260612` | `26.1.0.20260724` | 2026-07-24 (2 days ago) | 2026-07-31 (in 5 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.6.0` | 2026-07-31 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`95541fcb`](https://github.com/kdeldycke/mail-deduplicate/commit/95541fcb47159a146fb464d3b1367353a4c354a6)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/95541fcb47159a146fb464d3b1367353a4c354a6/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/95541fcb47159a146fb464d3b1367353a4c354a6/.github/workflows/autofix.yaml)
- **Run**: [#882.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/30207233478)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.0`