### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,8 +58,8 @@ jobs:
     outputs:
       metadata: ${{ steps.metadata.outputs.metadata }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -85,10 +85,10 @@ jobs:
     # We keep going when a job flagged as not stable fails.
     continue-on-error: ${{ matrix.state == 'unstable' }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-tags: true
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation, so the windows-11-arm cell would silently test emulated x86_64 Python
@@ -192,10 +192,10 @@ jobs:
       - metadata
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-tags: true
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project
@@ -239,7 +239,7 @@ jobs:
       GIT_URL: git+https://github.com/${{ github.repository }}
       PACKAGE: ${{ fromJSON(needs.metadata.outputs.metadata).package_name }}
     steps:
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-21` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [actions/checkout](https://github.com/actions/checkout) | [`v7.0.0` → `v7.0.1`](https://github.com/actions/checkout/compare/v7.0.0...v7.0.1) | 2026-07-20 (a week ago) |
| [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) | [`v8.3.2` → `v9.0.0`](https://github.com/astral-sh/setup-uv/compare/v8.3.2...v9.0.0) | 2026-07-21 (a week ago) |

### Release notes

<details>
<summary><code>actions/checkout</code></summary>

#### [`v7.0.1`](https://github.com/actions/checkout/releases/tag/v7.0.1)

##### What's Changed
* skip running unsafe pr check if input is default by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2518
* trim only ascii whitespace for branch by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2521
* escape values passed to --unset by @​aiqiaoy in https://redirect.github.com/actions/checkout/pull/2530
* Various dependency updates 

**Full Changelog**: https://redirect.github.com/actions/checkout/compare/v7...v7.0.1

</details>

<details>
<summary><code>astral-sh/setup-uv</code></summary>

#### [`v9.0.0`](https://github.com/astral-sh/setup-uv/releases/tag/v9.0.0)

##### Changes

This release disables the default cache cache pruning to ease the load on the PyPi infrastructure.
Since users might experience more GitHub Actions cache usage which might result in higher costs this is marked as a breaking change. To read more on why we did this (now) you can read the detailed analysis and reasoning in #​967

Besides this big breaking change we also have a small bugfix while building caches for linux distributions that behave a big different than the "big ones" and a speed up in version resolution by only reading the version manifest until a matching version is found saving runtime and network bandwith.

##### 🚨 Breaking changes

- Change `prune-cache` default to `false` @​charliermarsh (#​967)

##### 🐛 Bug fixes

- fix: fall back to distribution ID when os-release has no version field @​cxzhong (#​961)

##### 🚀 Enhancements

- Speed up version client by partial response reads @​eifinger (#​807)

##### 🧰 Maintenance

- chore: update known checksums for 0.11.30 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​968)
- chore: update known checksums for 0.11.29 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​960)

##### 📚 Documentation

- docs: update version references to v8.3.2 @[github-actions[bot]](https://redirect.github.com/apps/github-actions) (#​949)

##### ⬆️ Dependency updates

- chore(deps): roll up Dependabot updates @​eifinger (#​970)
- chore(deps): roll up Dependabot updates @​eifinger (#​962)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`53bf84f3`](https://github.com/kdeldycke/mail-deduplicate/commit/53bf84f3cb923fbbba073408c5d04942ff3e20f8)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/53bf84f3cb923fbbba073408c5d04942ff3e20f8/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/53bf84f3cb923fbbba073408c5d04942ff3e20f8/.github/workflows/autofix.yaml)
- **Run**: [#892.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/30451212111)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.3.1`