### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ typing = [
 [tool.uv]
 # Pin uv to a narrow range so every contributor and CI runner resolves uv.lock
 # with the same resolver (astral-sh/setup-uv reads this automatically).
-required-version = ">=0.11.23,<0.13"
+required-version = ">=0.12"
 # The docs are only built on modern Python, letting the docs group adopt
 # packages (like myst-parser 5.1) that dropped support for our older floors.
 dependency-groups.docs = { requires-python = ">= 3.14" }

--- a/uv.lock
+++ b/uv.lock
@@ -1136,11 +1136,11 @@ wheels = [
 
 [[package]]
 name = "types-boltons"
-version = "26.1.0.20260722"
+version = "26.1.0.20260724"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/93/2bf0fb36a9a414b2355358800c189e06e7aa373abb1731dea774acd33d04/types_boltons-26.1.0.20260722.tar.gz", hash = "sha256:9cb5d0497343361a6a834fff91498d607b34ce6f3fe5c8cdc59ba6b78d9c5538", size = 22249, upload-time = "2026-07-22T04:55:57.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/33/c22cc4c7d472c378c86643acb2a33ed972a9f17687a3b05c672ae621fdb6/types_boltons-26.1.0.20260724.tar.gz", hash = "sha256:63695b95add313f714d733729002c48e333f13e807b8795572e74fa47a8ae2ae", size = 22261, upload-time = "2026-07-24T04:58:09.764Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/0c/b6e4252b5ed8e130f15ccb22c58b5c9dbe32933120acca7b3ba9aa4704b9/types_boltons-26.1.0.20260722-py3-none-any.whl", hash = "sha256:4f129f96dd7f96a670e12ae22d93968151f6c7e9d530e598fd9683a22df02423", size = 28723, upload-time = "2026-07-22T04:55:56.407Z" },
+    { url = "https://files.pythonhosted.org/packages/77/88/ec6a17cdd63ceb8c0ebc55f253bc6cd2943d5e1db24a0a7aa1888a5005a4/types_boltons-26.1.0.20260724-py3-none-any.whl", hash = "sha256:ec6edf04de47b435d21ca44f4081f7572e3eeb6fcd3eeab88130c53529503fce", size = 28721, upload-time = "2026-07-24T04:58:08.849Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-07-24`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [types-boltons](https://pypi.org/project/types-boltons/) | [`26.1.0.20260722` → `26.1.0.20260724`](https://github.com/python/typeshed/compare/v26.1.0.20260722...v26.1.0.20260724) | 2026-07-24 (a week ago) |

### Release notes

<details>
<summary><code>types-boltons</code></summary>

[Changelog](https://redirect.github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/boltons.md)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.7.0` | `8.8.0` | 2026-07-31 (just now) | 2026-08-07 (in a week) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.7.0` | 2026-08-06 (in 6 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.1` | 2026-08-03 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`53afbf9b`](https://github.com/kdeldycke/mail-deduplicate/commit/53afbf9bdc20a9e14338398682543efe17b2abdd)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/53afbf9bdc20a9e14338398682543efe17b2abdd/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/53afbf9bdc20a9e14338398682543efe17b2abdd/.github/workflows/autofix.yaml)
- **Run**: [#916.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/30665265501)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.0`