### PR TITLE
Sync `uv.lock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,14 +164,6 @@ required-version = ">=0.11.15"
 dependency-groups.docs = { requires-python = ">= 3.14" }
 # Cooldown buffer before adopting newly released packages.
 exclude-newer = "1 week"
-# Per-package cooldown control. A fixed date holds a package at the version
-# available then (the day after it shipped), so `uv lock --upgrade` keeps that
-# version instead of tracking newer releases. `sync-uv-lock` freezes new
-# bypasses at that date and prunes each entry once its held version ages past
-# `exclude-newer`, returning the package to the normal cooldown. click-extra
-# 8.7.0 is let through early: it ships the config machinery cli.py depends on
-# (detailed in the runtime dependency note above).
-exclude-newer-package = { click-extra = "2026-07-31T00:00:00Z", extra-platforms = "2026-07-28T00:00:00Z" }
 # Package is at root level, not in "./src/".
 build-backend.module-root = ""
 

--- a/uv.lock
+++ b/uv.lock
@@ -10,10 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
-[options.exclude-newer-package]
-click-extra = "2026-07-31T00:00:00Z"
-extra-platforms = "2026-07-28T00:00:00Z"
-
 [[package]]
 name = "accessible-pygments"
 version = "0.0.5"


### PR DESCRIPTION
## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.7.0` | `8.8.1` | 2026-08-02 (5 days ago) | 2026-08-09 (in 2 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.2` | `7.15.4` | 2026-08-06 (a day ago) | 2026-08-13 (in 6 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.1` | `13.6.0` | 2026-08-03 (4 days ago) | 2026-08-10 (in 3 days) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (3 days ago) | 2026-08-11 (in 4 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (just now) | 2026-08-14 (in a week) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (4 days ago) | 2026-08-10 (in 3 days) |
| [whenever](https://pypi.org/project/whenever/) | `0.10.3` | `0.10.4` | 2026-08-02 (5 days ago) | 2026-08-09 (in 2 days) |

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | 🧹 cleared: `8.7.0` | 2026-08-06 |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | 🧹 cleared: `13.5.1` | 2026-08-03 |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`a3181cea`](https://github.com/kdeldycke/mail-deduplicate/commit/a3181ceaee2981539f6c0daf1bbc959f8cb51a4d)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/a3181ceaee2981539f6c0daf1bbc959f8cb51a4d/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/a3181ceaee2981539f6c0daf1bbc959f8cb51a4d/.github/workflows/autofix.yaml)
- **Run**: [#932.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/31169739758)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`