### PR TITLE
Bump minor version to `v9.3.0`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [`9.2.1.dev0` (unreleased)](https://github.com/kdeldycke/mail-deduplicate/compare/v9.2.0...main)
+## [`9.3.0.dev0` (unreleased)](https://github.com/kdeldycke/mail-deduplicate/compare/v9.2.0...main)
 
 > [!WARNING]
 > This version is **not released yet** and is under active development.

--- a/citation.cff
+++ b/citation.cff
@@ -8,7 +8,7 @@ authors:
     email: kevin@deldycke.com
     orcid: "https://orcid.org/0000-0001-9748-9014"
 doi: 10.5281/zenodo.7364256
-version: 9.2.1.dev0
+version: 9.3.0.dev0
 # The release date is kept up to date by repomatic's release workflow.
 date-released: 2026-08-07
 url: "https://github.com/kdeldycke/mail-deduplicate"

--- a/mail_deduplicate/__init__.py
+++ b/mail_deduplicate/__init__.py
@@ -17,4 +17,4 @@
 
 from __future__ import annotations
 
-__version__ = "9.2.1.dev0"
+__version__ = "9.3.0.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [ "uv-build>=0.8" ]
 [project]
 # Docs: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 name = "mail-deduplicate"
-version = "9.2.1.dev0"
+version = "9.3.0.dev0"
 description = "📧 CLI to deduplicate mails from mail boxes"
 readme = "readme.md"
 keywords = [
@@ -81,7 +81,7 @@ dependencies = [
 ]
 urls.Changelog = "https://github.com/kdeldycke/mail-deduplicate/blob/main/changelog.md"
 urls.Documentation = "https://kdeldycke.github.io/mail-deduplicate"
-urls.Download = "https://github.com/kdeldycke/mail-deduplicate/releases/tag/v9.2.1.dev0"
+urls.Download = "https://github.com/kdeldycke/mail-deduplicate/releases/tag/v9.3.0.dev0"
 urls.Funding = "https://github.com/sponsors/kdeldycke"
 urls.Homepage = "https://github.com/kdeldycke/mail-deduplicate"
 urls.Issues = "https://github.com/kdeldycke/mail-deduplicate/issues"
@@ -171,8 +171,8 @@ build-backend.module-root = ""
 product-name = "Mail Deduplicate"
 file-description = "📧 CLI to deduplicate mails from mail boxes"
 copyright = "Kevin Deldycke <kevin@deldycke.com> and contributors. Distributed under GPL-2.0-or-later license."
-file-version = "9.2.1"
-product-version = "9.2.1"
+file-version = "9.3.0"
+product-version = "9.3.0"
 # click-extra ships themes.toml as package data loaded via importlib.resources;
 # Nuitka does not auto-bundle non-Python data files, so the binary falls back
 # to the no-color theme at startup unless it is declared here.
@@ -248,7 +248,7 @@ run.source = [ "mail_deduplicate" ]
 report.precision = 2
 
 [tool.bumpversion]
-current_version = "9.2.1.dev0"
+current_version = "9.3.0.dev0"
 # Parse versions with an optional .devN suffix (PEP 440).
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.dev(?P<dev>\\d+))?"
 serialize = [

--- a/uv.lock
+++ b/uv.lock
@@ -456,7 +456,7 @@ wheels = [
 
 [[package]]
 name = "mail-deduplicate"
-version = "9.2.1.dev0"
+version = "9.3.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Ready to be merged into `main` branch, at the discretion of the maintainers, to bump the minor part of the version number. Version bumps are scheduled daily and also triggered after releases. See the [`bump-version` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-changelog-yaml-jobs) for details.

## To bump version to `v9.3.0`

1. **Click `Ready for review`** button below, to get this PR out of `Draft` mode

2. **Click `Rebase and merge`** button below


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`bump-version`](https://kdeldycke.github.io/repomatic/workflows.html#bump-version-bump-version)
- **Trigger**: `workflow_run`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`fc7f503a`](https://github.com/kdeldycke/mail-deduplicate/commit/fc7f503aaa1c9a65c90a00fb2bed6397d3f705e2)
- **Job**: [`bump-version`](https://github.com/kdeldycke/mail-deduplicate/blob/fc7f503aaa1c9a65c90a00fb2bed6397d3f705e2/.github/workflows/changelog.yaml)
- **Workflow**: [`changelog.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/fc7f503aaa1c9a65c90a00fb2bed6397d3f705e2/.github/workflows/changelog.yaml)
- **Run**: [#350.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/31188298856)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`