### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -387,11 +387,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "13.5.1"
+version = "13.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/4d/85b286ccdffdb9c93f537428dbab9616f15f89ed40f9217ac21bc21e01b6/extra_platforms-13.5.1.tar.gz", hash = "sha256:89100acdf8aa28f8c589981b653e9f42a5bd68ce932c33cbd6faa7a81731c7c6", size = 465562, upload-time = "2026-07-27T19:28:20.5Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/85/fca1871c5a7662b54ae07798e4d4890825640ee158d87df5bcfb487c5e07/extra_platforms-13.5.2.tar.gz", hash = "sha256:435510ff55885caa4199fb7f698b3a74ca00e47c0e9e3352c6b9855b790efabd", size = 460276, upload-time = "2026-08-01T13:22:17.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/03/4d65c1bb5064cc895bac491ee34e50a23058dc5b80e718e9f4ad386c7eb4/extra_platforms-13.5.1-py3-none-any.whl", hash = "sha256:b6fd87f13933a19f073eb329848b0722c8037b657bc519befc19cdd56384a5bc", size = 91123, upload-time = "2026-07-27T19:28:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/88/24/0d0603aeb895469057e909951f0dba40577965d4dbbb0100f22ecbb370c7/extra_platforms-13.5.2-py3-none-any.whl", hash = "sha256:b79e5d5b002822022f33f8ebb9a60987bd7757dfdc2ce92cfc7e8cd3134b8883", size = 97116, upload-time = "2026-08-01T13:22:15.564Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-01`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | [`13.5.1` → `13.5.2`](https://github.com/kdeldycke/extra-platforms/compare/v13.5.1...v13.5.2) | 2026-08-01 (a week ago) |

### Release notes

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.5.2`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.5.2)

> [!NOTE]
> `13.5.2` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.5.2/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.5.2).

- Reorganize the installation page: quick start first, then `uvx` try-it tabs, install methods, the Python compatibility matrix and the dependency graph.
- Register MyST heading anchors so in-page documentation links resolve at build time.
- Render the CLI `--help` screen live in the documentation so its option list can't drift from the code.

**Full changelog**: [`v13.5.1...v13.5.2`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.5.1...v13.5.2)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.8.0` | `8.8.1` | 2026-08-02 (6 days ago) | 2026-08-09 (in a day) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.2` | `7.15.4` | 2026-08-06 (2 days ago) | 2026-08-13 (in 5 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.5.2` | `13.6.0` | 2026-08-03 (5 days ago) | 2026-08-10 (in 2 days) |
| [packaging](https://pypi.org/project/packaging/) | `26.2` | `26.3` | 2026-08-04 (4 days ago) | 2026-08-11 (in 3 days) |
| [platformdirs](https://pypi.org/project/platformdirs/) | `4.11.0` | `4.11.1` | 2026-08-07 (a day ago) | 2026-08-14 (in 6 days) |
| [soupsieve](https://pypi.org/project/soupsieve/) | `2.9.1` | `2.9.2` | 2026-08-07 (a day ago) | 2026-08-14 (in 6 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.0` | `3.13.2` | 2026-08-03 (5 days ago) | 2026-08-10 (in 2 days) |
| [whenever](https://pypi.org/project/whenever/) | `0.10.3` | `0.10.5` | 2026-08-07 (a day ago) | 2026-08-14 (in 6 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://kdeldycke.github.io/repomatic/workflows.html#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`7bb04ec1`](https://github.com/kdeldycke/mail-deduplicate/commit/7bb04ec132f722e8956d7f54986f505ba0d73c2f)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/7bb04ec132f722e8956d7f54986f505ba0d73c2f/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/7bb04ec132f722e8956d7f54986f505ba0d73c2f/.github/workflows/autofix.yaml)
- **Run**: [#964.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/31261757000)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.4.1`