### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.2"
+          version: "0.12.4"
       - name: Run repomatic metadata
         id: metadata
         run: >
@@ -112,7 +112,7 @@ jobs:
           fetch-tags: true
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.2"
+          version: "0.12.4"
       - name: Force native ARM64 Python on Windows ARM64
         # Workaround for https://github.com/astral-sh/uv/issues/12906: uv defaults to x86_64 Python on ARM64 Windows,
         # relying on transparent emulation, so the windows-11-arm cell would silently test emulated x86_64 Python
@@ -198,7 +198,7 @@ jobs:
           fetch-tags: true
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.2"
+          version: "0.12.4"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Install project
@@ -229,7 +229,7 @@ jobs:
     steps:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          version: "0.12.2"
+          version: "0.12.4"
       - name: Install Python
         run: uv --no-progress venv --python 3.14
       - name: Run stable CLI


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-21` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [uv](https://pypi.org/project/uv/) | `0.12.2` → `0.12.4` | 2026-08-13 (a month ago) |

### Release notes

<details>
<summary><code>uv</code></summary>

#### [`0.12.3`](https://github.com/astral-sh/uv/releases/tag/0.12.3)

##### Release Notes

Released on 2026-08-07.

###### Python

- Add CPython 3.13.15 ([#​20997](https://redirect.github.com/astral-sh/uv/pull/20997))

###### Preview features

- Add `--output-format` to select automatic, human-readable, or raw-byte output for `uv cache size` ([#​20992](https://redirect.github.com/astral-sh/uv/pull/20992))
- Preserve JSON output from `uv workspace metadata --quiet` while suppressing diagnostics ([#​20991](https://redirect.github.com/astral-sh/uv/pull/20991))
- Reduce memory usage for large workspaces by streaming `uv workspace metadata` JSON output ([#​20990](https://redirect.github.com/astral-sh/uv/pull/20990))

###### Performance

- Reduce Linux startup latency by initializing the workspace cache before spawning another thread ([#​20989](https://redirect.github.com/astral-sh/uv/pull/20989))
- Reuse compiled workspace exclusion patterns during workspace discovery ([#​20988](https://redirect.github.com/astral-sh/uv/pull/20988))
- Speed up conflict-heavy resolutions by avoiding materialized range complements ([#​20982](https://redirect.github.com/astral-sh/uv/pull/20982))
- Avoid slow procfs reads during Python interpreter discovery on Linux ([#​20987](https://redirect.github.com/astral-sh/uv/pull/20987))

###### Documentation

- Add PEP 740 attestations to the GitHub Actions publishing example ([#​20986](https://redirect.github.com/astral-sh/uv/pull/20986))
- Restrict the GitHub Actions publishing example to Python version tags ([#​20973](https://redirect.github.com/astral-sh/uv/pull/20973))
- Correct `--python-pin` to `--pin-python` in the `uv init --bare` example ([#​20876](https://redirect.github.com/astral-sh/uv/pull/20876))

##### Install uv 0.12.3

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/uv/releases/download/0.12.3/uv-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.3)

#### [`0.12.4`](https://github.com/astral-sh/uv/releases/tag/0.12.4)

##### Release Notes

Released on 2026-08-13.

###### Enhancements

- Prefer post-quantum key exchange and enable opt-in TLS diagnostics ([#​21054](https://redirect.github.com/astral-sh/uv/pull/21054))
- Accept whitespace before versions in noncompliant wildcard comparisons such as `Requires-Python: >= 3.5.*` ([#​21012](https://redirect.github.com/astral-sh/uv/pull/21012))
- Report a specific error when a PEP 723 closing tag contains trailing whitespace or other content ([#​20944](https://redirect.github.com/astral-sh/uv/pull/20944))
- Omit source-span carets from diagnostics for empty PEP 508 requirements ([#​21094](https://redirect.github.com/astral-sh/uv/pull/21094))

###### Preview features

- Add `uv check --no-install-project` and respect `UV_NO_INSTALL_PROJECT` to install dependencies without building or installing the project ([#​21085](https://redirect.github.com/astral-sh/uv/pull/21085))
- Make the ty subprocess invoked by `uv check` honor uv's color and progress settings, including quiet mode ([#​21086](https://redirect.github.com/astral-sh/uv/pull/21086))

###### Performance

- Speed up resolutions with long runs of unavailable package versions by coalescing gaps in the resolver's version ranges ([#​20804](https://redirect.github.com/astral-sh/uv/pull/20804))
- Speed up Simple API parsing by deserializing PyPI and Pyx file metadata directly ([#​21041](https://redirect.github.com/astral-sh/uv/pull/21041))

###### Bug fixes

- Use windowed `pythonw.exe` launchers for virtual environments created from managed Python minor-version links ([#​19235](https://redirect.github.com/astral-sh/uv/pull/19235))
- Allow `uv lock` to proceed when `.venv` is an unusable project environment ([#​21068](https://redirect.github.com/astral-sh/uv/pull/21068))
- Respect `fork-strategy` when ordering forks created from `environments` or existing lockfile `resolution-markers` ([#​21000](https://redirect.github.com/astral-sh/uv/pull/21000))

... [Full release notes](https://github.com/astral-sh/uv/releases/tag/0.12.4)

</details>

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`workflow-pins.sync`](https://repomatic.net/configuration#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/mail-deduplicate/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://repomatic.net/workflows#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`2892f7da`](https://github.com/kdeldycke/mail-deduplicate/commit/2892f7dab11bce455b2b69fecadbc0fffec09137)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/mail-deduplicate/blob/2892f7dab11bce455b2b69fecadbc0fffec09137/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/mail-deduplicate/blob/2892f7dab11bce455b2b69fecadbc0fffec09137/.github/workflows/autofix.yaml)
- **Run**: [#986.1](https://github.com/kdeldycke/mail-deduplicate/actions/runs/33170961237)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.14.0`
